### PR TITLE
certs: Adding CA and CRL functionality

### DIFF
--- a/docs/snphost.1.adoc
+++ b/docs/snphost.1.adoc
@@ -100,32 +100,32 @@ COMMANDS
     -h, --help          Show a help message
 
 *snphost fetch ca*::
-	usage: snphost fetch ca [ der, pem ] FILE-PATH
+	usage: snphost fetch ca [ der, pem ] DIR-PATH
 
-        This command fetches the host system's certificate chain  and writes
-		the encoded certificates to the file at path FILE-PATH. Users must
-		specify which format they would like the certificate to be encoded
-		in (DER or PEM).
+        This command fetches the host system's certificate chain and writes
+        the encoded certificates to the directory at path DIR-PATH. Users must
+        specify which format they would like the certificate to be encoded
+        in (DER or PEM).
 
  options:
     -h, --help          Show a help message
 
 *snphost fetch vcek*::
-	usage: snphost fetch vcek [ der, pem ] FILE-PATH
+	usage: snphost fetch vcek [ der, pem ] DIR-PATH
 
         This command fetches the host system's versioned chip endorsement
-		key (VCEK) and writes the encoded certificate to the file at path
-		FILE-PATH. Users must specify which format they would like the
-		certificate to be encoded in (DER or PEM).
+        key (VCEK) and writes the encoded certificate to the directory at path
+        DIR-PATH. Users must specify which format they would like the
+        certificate to be encoded in (DER or PEM).
 
  options:
     -h, --help          Show a help message
 
 *snphost fetch crl*::
-	usage: snphost fetch crl FILE-PATH
+	usage: snphost fetch crl DIR-PATH
 
         This command fetches the host system's certificate revokation list
-		(CRL) and writes the encoded certificate to the file at path FILE-PATH.
+        (CRL) and writes the encoded list to the directory at path DIR-PATH.
 
  options:
     -h, --help          Show a help message

--- a/docs/snphost.1.adoc
+++ b/docs/snphost.1.adoc
@@ -102,7 +102,7 @@ COMMANDS
 *snphost fetch ca*::
 	usage: snphost fetch ca [ der, pem ] DIR-PATH
 
-        This command fetches the host system's certificate chain and writes
+        This command fetches the host system's CA certificate chain and writes
         the encoded certificates to the directory at path DIR-PATH. Users must
         specify which format they would like the certificate to be encoded
         in (DER or PEM).

--- a/docs/snphost.1.adoc
+++ b/docs/snphost.1.adoc
@@ -99,12 +99,33 @@ COMMANDS
  options:
     -h, --help          Show a help message
 
-*snphost vcek*::
-	usage: snphost vcek [ der, pem ] FILE-PATH
+*snphost fetch ca*::
+	usage: snphost fetch ca [ der, pem ] FILE-PATH
 
-        This command fetches the host system's VCEK and writes the encoded
-        certificate to the file at path FILE-PATH. User must specify which
-        format they would like the certificate to be encoded in (DER or PEM).
+        This command fetches the host system's certificate chain  and writes
+		the encoded certificates to the file at path FILE-PATH. Users must
+		specify which format they would like the certificate to be encoded
+		in (DER or PEM).
+
+ options:
+    -h, --help          Show a help message
+
+*snphost fetch vcek*::
+	usage: snphost fetch vcek [ der, pem ] FILE-PATH
+
+        This command fetches the host system's versioned chip endorsement
+		key (VCEK) and writes the encoded certificate to the file at path
+		FILE-PATH. Users must specify which format they would like the
+		certificate to be encoded in (DER or PEM).
+
+ options:
+    -h, --help          Show a help message
+
+*snphost fetch crl*::
+	usage: snphost fetch crl FILE-PATH
+
+        This command fetches the host system's certificate revokation list
+		(CRL) and writes the encoded certificate to the file at path FILE-PATH.
 
  options:
     -h, --help          Show a help message


### PR DESCRIPTION
Previously, `snphost` was missing functionality to pull certificate chains and certificate revocation lists from the KDS. This adds that functionality to bring `snphost` into parody with other tools.