### PR TITLE
In vcek url use reported_tcb_version

### DIFF
--- a/src/cert/fetch/vcek.rs
+++ b/src/cert/fetch/vcek.rs
@@ -76,8 +76,8 @@ pub fn vcek_url() -> Result<String> {
     let gen = ProcessorGeneration::current()?;
 
     Ok(format!("https://kdsintf.amd.com/vcek/v1/{}/{}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
-                         gen.to_string(), id, status.platform_tcb_version.bootloader,
-                         status.platform_tcb_version.tee,
-                         status.platform_tcb_version.snp,
-                         status.platform_tcb_version.microcode))
+                         gen.to_string(), id, status.reported_tcb_version.bootloader,
+                         status.reported_tcb_version.tee,
+                         status.reported_tcb_version.snp,
+                         status.reported_tcb_version.microcode))
 }


### PR DESCRIPTION
## Description:
- change platform_tcb_version to reported_tcb_version for bootloader, tee, snp, microcode

## Linked Issues
[Issue-21](https://github.com/virtee/snphost/issues/21)

## Testing
- attempted run locally but ran into this error on both main and my branch (probably because I don't have the correct drivers in wsl) I am opening the PR because I believe the code is correct and will work in the correct environment
```
ERROR: unable to open /dev/sev
Error: unable to open /dev/sev

Caused by:
    No such file or directory (os error 2)
```