### PR TITLE
fix: remove subcommand trait on ok/commit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@ enum SnpHostCmd {
     Import(import::Import),
 
     /// Probe system for SEV-SNP support
-    #[command(subcommand)]
     Ok,
 
     /// Modify the SNP configuration
@@ -56,7 +55,6 @@ enum SnpHostCmd {
     Fetch(fetch::Fetch),
 
     /// Commit current firmware and TCB versions to PSP
-    #[command(subcommand)]
     Commit,
 }
 


### PR DESCRIPTION
Remove `subcommand` trait from `Ok` and `Commit`. This fixes the prior behaviour where the usage was printed rather than the expected functionality occurring.

With the fix:

```
$ sudo ./target/release/snphost ok
[ PASS ] - AMD CPU
[ PASS ]   - Microcode support
[ PASS ]   - Secure Memory Encryption (SME)
[ PASS ]     - SME: Enabled in MSR
[ PASS ]   - Secure Encrypted Virtualization (SEV)
[ PASS ]     - Encrypted State (SEV-ES)
[ PASS ]       - SEV-ES INIT: Enabled
[ PASS ]     - SEV INIT: SEV is INIT, but not currently running a guest
[ PASS ]     - Secure Nested Paging (SEV-SNP)
[ PASS ]       - VM Permission Levels
[ PASS ]         - Number of VMPLs: 4
[ PASS ]       - SNP: Enabled in MSR
[ PASS ]       - SEV Firmware Version: Sev firmware version: 1.55
[ PASS ]       - SNP INIT: SNP is INIT
[ PASS ]     - Physical address bit reduction: 5
[ PASS ]     - C-bit location: 51
[ PASS ]     - Number of encrypted guests supported simultaneously: 509
[ PASS ]     - Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
[ PASS ]     - Reading /dev/sev: /dev/sev readable
[ PASS ]     - Writing /dev/sev: /dev/sev writable
[ PASS ]   - Page flush MSR: ENABLED
[ PASS ] - KVM supported: API version: 12
[ PASS ]   - SEV enabled in KVM: enabled
[ PASS ]   - SEV-ES enabled in KVM: enabled
[ PASS ]   - SEV-SNP enabled in KVM: enabled
[ PASS ] - Memlock resource limit: Soft: 33598480384 | Hard: 33598480384
[ PASS ] - RMP table addresses: Addresses: 367001600 - 1450180607
[ PASS ] - RMP INIT: RMP is INIT
[ PASS ] - Comparing TCB values: TCB versions match 

 Platform TCB version: 
TCB Version:
  Microcode:   211
  SNP:         21
  TEE:         0
  Boot Loader: 4
   
 Reported TCB version: 
TCB Version:
  Microcode:   211
  SNP:         21
  TEE:         0
  Boot Loader: 4

```

```sh
$ sudo ./target/release/snphost commit
$ echo $?
0
```

Fixes #52 