### PR TITLE
Updating dependencies and fixing fetch CA bug for Turin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libredox"
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97bd0b2e2d937951add10c8512a2dacc6ad29b39e5c5f26565a3e443329857d"
+checksum = "b06afe5192a43814047ea0072f4935f830a1de3c8cb43b56c90ae6918468b94d"
 dependencies = [
  "base64",
  "bincode",
@@ -658,9 +658,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ is-it-maintained-open-issues = { repository = "virtee/snphost" }
 
 [dependencies]
 anyhow = "1.0.83"
-sev = { version = "4.0.0", features = ['openssl']}
+sev = { version = "5.0.0" , features = ['openssl']}
 env_logger = "0.10.1"
 clap = { version = "4.5", features = [ "derive" ] }
 colorful = "0.2.2"
-libc = "0.2.154"
+libc = "0.2.161"
 curl = "0.4"
 msru = "0.2.0"

--- a/src/cert/fetch/ca.rs
+++ b/src/cert/fetch/ca.rs
@@ -3,7 +3,7 @@
 use super::*;
 use anyhow::{Context, Result};
 use curl::easy::Easy;
-use sev::certs::snp::{ca::Chain, Certificate};
+use sev::certs::snp::ca::Chain;
 use std::{
     fs::{create_dir_all, OpenOptions},
     io::Write,
@@ -76,10 +76,7 @@ pub fn fetch(url: &str) -> Result<Chain> {
     transfer.perform()?;
     drop(transfer);
 
-    Ok(Chain {
-        ask: Certificate::from_pem(&buf[..2325])?,
-        ark: Certificate::from_pem(&buf[2325..])?,
-    })
+    Ok(Chain::from_pem_bytes(&buf)?)
 }
 
 fn ca_chain_url() -> Result<String> {

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -475,7 +475,7 @@ pub fn cmd(quiet: bool) -> Result<()> {
         Ok(())
     } else {
         Err(anyhow::anyhow!(
-            "One or more tests in sevctl-ok reported a failure"
+            "One or more tests in snphost ok reported a failure"
         ))
     }
 }


### PR DESCRIPTION
Bumping to latest stable sev library 5.0.0

There was also a recent update to the SEV library libc dependency. So the dependency in the tool has to be updated too.

Turin certificates are a different size from previous generation certificates, with the new stack from pem functionality from the library, we can get around this bug.