### PR TITLE
ok: Update RMP_INIT check to account for other bitflags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,8 +545,7 @@ dependencies = [
 [[package]]
 name = "sev"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06afe5192a43814047ea0072f4935f830a1de3c8cb43b56c90ae6918468b94d"
+source = "git+http://github.com/tylerfanelli/sev.git?branch=platform-status-alias-check#bf1888b00147f202bb0a7943d2b4281e6fefdc8e"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ is-it-maintained-open-issues = { repository = "virtee/snphost" }
 
 [dependencies]
 anyhow = "1.0.83"
-sev = { version = "5.0.0" , features = ['openssl']}
+sev = { git = "http://github.com/tylerfanelli/sev.git" , branch = "platform-status-alias-check", features = ['openssl']}
 env_logger = "0.10.1"
 clap = { version = "4.5", features = [ "derive" ] }
 colorful = "0.2.2"

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -298,7 +298,26 @@ fn collect_tests() -> Vec<Test> {
                                     name: "SNP INIT",
                                     gen_mask: SNP_MASK,
                                     run: Box::new(|| snp_ioctl(SnpStatusTest::Snp)),
-                                    sub: vec![],
+                                    sub: vec![
+                                        Test {
+                                            name: "Read RMP tables",
+                                            gen_mask: SNP_MASK,
+                                            run: Box::new(get_rmp_address),
+                                            sub: vec![],
+                                        },
+                                        Test {
+                                            name: "RMP INIT",
+                                            gen_mask: SNP_MASK,
+                                            run: Box::new(|| snp_ioctl(SnpStatusTest::Rmp)),
+                                            sub: vec![],
+                                        },
+                                        Test {
+                                            name: "Alias check",
+                                            gen_mask: SNP_MASK,
+                                            run: Box::new(|| snp_ioctl(SnpStatusTest::AliasCheck)),
+                                            sub: vec![],
+                                        },
+                                    ],
                                 },
                             ],
                         },
@@ -443,24 +462,6 @@ fn collect_tests() -> Vec<Test> {
             name: "memlock limit",
             gen_mask: SEV_MASK,
             run: Box::new(memlock_rlimit),
-            sub: vec![],
-        },
-        Test {
-            name: "Read RMP tables",
-            gen_mask: SNP_MASK,
-            run: Box::new(get_rmp_address),
-            sub: vec![],
-        },
-        Test {
-            name: "RMP INIT",
-            gen_mask: SNP_MASK,
-            run: Box::new(|| snp_ioctl(SnpStatusTest::Rmp)),
-            sub: vec![],
-        },
-        Test {
-            name: "Alias check",
-            gen_mask: SNP_MASK,
-            run: Box::new(|| snp_ioctl(SnpStatusTest::AliasCheck)),
             sub: vec![],
         },
         Test {
@@ -787,7 +788,7 @@ fn get_rmp_address() -> TestResult {
         TestResult {
             name: "RMP table addresses".to_string(),
             stat: TestState::Pass,
-            mesg: format!("Addresses: {} - {}", rmp_base, rmp_end).into(),
+            mesg: format!("0x{:x} - 0x{:x}", rmp_base, rmp_end).into(),
         }
     }
 }

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -815,7 +815,7 @@ fn snp_ioctl(test: SnpStatusTest) -> TestResult {
             }
         }
         SnpStatusTest::Rmp => {
-            if status.is_rmp_init == 1 {
+            if (status.is_rmp_init & PlatformInit::IS_RMP_INIT).bits() != 0 {
                 TestResult {
                     name: format!("{}", SnpStatusTest::Rmp),
                     stat: TestState::Pass,

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -89,7 +89,7 @@ impl fmt::Display for SevStatusTests {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
             SevStatusTests::Sev => "SEV initialized",
-            SevStatusTests::Firmware => "SEV Firmware Version",
+            SevStatusTests::Firmware => "SEV firmware version",
             SevStatusTests::SevEs => "SEV-ES initialized",
         };
         write!(f, "{}", s)
@@ -199,6 +199,12 @@ fn collect_tests() -> Vec<Test> {
                     }),
                     sub: vec![
                         Test {
+                            name: "SEV Firmware Version",
+                            gen_mask: SNP_MASK,
+                            run: Box::new(|| sev_ioctl(SevStatusTests::Firmware)),
+                            sub: vec![],
+                        },
+                        Test {
                             name: "Encrypted State (SEV-ES)",
                             gen_mask: ES_MASK,
                             run: Box::new(|| {
@@ -286,12 +292,6 @@ fn collect_tests() -> Vec<Test> {
                                     name: "SEV-SNP",
                                     gen_mask: SNP_MASK,
                                     run: Box::new(snp_test),
-                                    sub: vec![],
-                                },
-                                Test {
-                                    name: "SEV Firmware Version",
-                                    gen_mask: SNP_MASK,
-                                    run: Box::new(|| sev_ioctl(SevStatusTests::Firmware)),
                                     sub: vec![],
                                 },
                                 Test {


### PR DESCRIPTION
With latest SEV-SNP firmware updates, more bitfields were added to STRUCT_PLATFORM_STATUS. The ok subcommand originally checked if the entire is_rmp_init byte was equal to one.

Instead, ensure that the IS_RMP_INIT bitflag of STRUCT_PLATFORM_STATUS is enabled, rather than checking the entire byte.