### PR TITLE
deps/sev: Point to upstream git commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 [[package]]
 name = "sev"
 version = "5.0.0"
-source = "git+http://github.com/tylerfanelli/sev.git?branch=platform-status-alias-check#bf1888b00147f202bb0a7943d2b4281e6fefdc8e"
+source = "git+http://github.com/virtee/sev.git?rev=8ec281db27953417a98441abe54b9a47a3e94ba8#8ec281db27953417a98441abe54b9a47a3e94ba8"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ is-it-maintained-open-issues = { repository = "virtee/snphost" }
 
 [dependencies]
 anyhow = "1.0.83"
-sev = { git = "http://github.com/tylerfanelli/sev.git" , branch = "platform-status-alias-check", features = ['openssl']}
+sev = { git = "http://github.com/virtee/sev.git" , rev = "8ec281db27953417a98441abe54b9a47a3e94ba8", features = ['openssl']}
 env_logger = "0.10.1"
 clap = { version = "4.5", features = [ "derive" ] }
 colorful = "0.2.2"


### PR DESCRIPTION
This is a temporary action as changes that are not (yet) part of an initial release were included. For now, we can point to the upstream sev repository from its latest commit.