### PR TITLE
Fix: Enabling config reset subcmd

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,6 @@ pub enum ConfigCmd {
     Set(set::Args),
 
     /// Reset the SEV-SNP Config to the last comitted version
-    #[command(subcommand)]
     Reset,
 }
 


### PR DESCRIPTION
Trying to call config reset would not run. By removing this flag, the command will run as expected.

## Summary by Sourcery

Bug Fixes:
- Enable the config reset subcommand by removing the #[command(subcommand)] attribute