### PR TITLE
Add FMC parameter to vcek URL for Turin

### DIFF
--- a/src/cert/fetch/vcek.rs
+++ b/src/cert/fetch/vcek.rs
@@ -97,6 +97,7 @@ pub fn vcek_url() -> Result<String> {
     );
 
     match processor_generation {
+        // Turin+ processors also require the FMC parameter to fetch VCEKs.
         ProcessorGeneration::Turin => {
             if let Some(fmc) = status.reported_tcb_version.fmc {
                 Ok(format!(


### PR DESCRIPTION
Turin generation processor should have a FMC value in TCB version, add this parameter to VCEK URL for command "show" and "fetch vcek"