### PR TITLE
VLEK: Add ASVK support

### DIFF
--- a/src/cert/export.rs
+++ b/src/cert/export.rs
@@ -70,7 +70,12 @@ pub fn cmd(export: Export) -> Result<()> {
                 }
                 ask = true;
 
-                "ask"
+                // Unless VLEK is encountered, assume VCEK style endorsement with ASK.
+                if vlek {
+                    "asvk"
+                } else {
+                    "ask"
+                }
             }
             CertType::VLEK => {
                 if vlek {

--- a/src/cert/import.rs
+++ b/src/cert/import.rs
@@ -86,6 +86,7 @@ fn entry_get_type(path: &PathBuf) -> Result<Option<CertType>> {
     match subs[0] {
         "ark" => Ok(Some(CertType::ARK)),
         "ask" => Ok(Some(CertType::ASK)),
+        "asvk" => Ok(Some(CertType::ASK)),
         "vlek" => Ok(Some(CertType::VLEK)),
         "vcek" => Ok(Some(CertType::VCEK)),
         _ => Ok(None),


### PR DESCRIPTION
With the release of the VLEK, there is a separate api endpoint for requesting VLEK signing keys which are known as an AMD Signing VLEK Key (ASVK). As the GHCB does not offer a unique UUID for ASVK, treat ASVK as ASK to include it in the cert table. The guest VM can tell ASVK from ASK by checking the endorser.