### PR TITLE
ci: replace and bump deprecated GitHub actions

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,6 +3,9 @@ name: Sign-off Check
 on:
   pull_request:
 
+permissions:  
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,35 +1,31 @@
-on: [push, pull_request]
 name: lint
+
+on: [push, pull_request]
+
+permissions:  
+  contents: read
+
 jobs:
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
           toolchain: nightly
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
+      - run: sudo apt-get update
       - run: sudo apt-get install -y asciidoctor
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
           toolchain: 1.80.0
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D clippy::all -D unused_imports -Dwarnings
+      - run: cargo clippy --locked --all-targets -- -D clippy::all -D unused_imports -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,20 +1,22 @@
-on: [push, pull_request]
 name: test
+
+on: [push, pull_request]
+
+permissions:  
+  contents: read
+
 jobs:
   test:
     name: ${{ matrix.toolchain }} (${{ matrix.profile.name }})
     runs-on: ubuntu-latest
     steps:
+      - run: sudo apt-get update
       - run: sudo apt-get install -y asciidoctor
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: ${{ matrix.profile.flag }}
+      - run: cargo test ${{ matrix.profile.flag }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This addresses the deprecation issues with `actions-rs/toolchain` and `actions/checkout@v2`. It suppresses deprecation notifications. For more details, please see https://github.com/virtee/snpguest/pull/128.