### PR TITLE
Fix some unecessary unsafe warnings

### DIFF
--- a/src/ok.rs
+++ b/src/ok.rs
@@ -102,7 +102,7 @@ fn collect_tests() -> Vec<Test> {
             name: "AMD CPU",
             gen_mask: SEV_MASK,
             run: Box::new(|| {
-                let res = unsafe { x86_64::__cpuid(0x0000_0000) };
+                let res = x86_64::__cpuid(0x0000_0000);
                 let name: [u8; 12] = unsafe { transmute([res.ebx, res.edx, res.ecx]) };
                 let name = from_utf8(&name[..]).unwrap_or("ERROR_FOUND");
 
@@ -126,7 +126,7 @@ fn collect_tests() -> Vec<Test> {
                         let cpu_name = {
                             let mut bytestr = Vec::with_capacity(48);
                             for cpuid in 0x8000_0002_u32..=0x8000_0004_u32 {
-                                let cpuid = unsafe { x86_64::__cpuid(cpuid) };
+                                let cpuid = x86_64::__cpuid(cpuid);
                                 let mut bytes: Vec<u8> =
                                     [cpuid.eax, cpuid.ebx, cpuid.ecx, cpuid.edx]
                                         .iter()
@@ -158,7 +158,7 @@ fn collect_tests() -> Vec<Test> {
                     name: "Secure Memory Encryption (SME)",
                     gen_mask: SEV_MASK,
                     run: Box::new(|| {
-                        let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                        let res = x86_64::__cpuid(0x8000_001f);
 
                         let stat = if (res.eax & 0x1) != 0 {
                             TestState::Pass
@@ -183,7 +183,7 @@ fn collect_tests() -> Vec<Test> {
                     name: "Secure Encrypted Virtualization (SEV)",
                     gen_mask: SEV_MASK,
                     run: Box::new(|| {
-                        let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                        let res = x86_64::__cpuid(0x8000_001f);
 
                         let stat = if (res.eax & (0x1 << 1)) != 0 {
                             TestState::Pass
@@ -208,7 +208,7 @@ fn collect_tests() -> Vec<Test> {
                             name: "Encrypted State (SEV-ES)",
                             gen_mask: ES_MASK,
                             run: Box::new(|| {
-                                let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                                let res = x86_64::__cpuid(0x8000_001f);
 
                                 let stat = if (res.eax & (0x1 << 3)) != 0 {
                                     TestState::Pass
@@ -239,7 +239,7 @@ fn collect_tests() -> Vec<Test> {
                             name: "Secure Nested Paging (SEV-SNP)",
                             gen_mask: SNP_MASK,
                             run: Box::new(|| {
-                                let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                                let res = x86_64::__cpuid(0x8000_001f);
 
                                 let stat = if (res.eax & (0x1 << 4)) != 0 {
                                     TestState::Pass
@@ -258,7 +258,7 @@ fn collect_tests() -> Vec<Test> {
                                     name: "VM Permission Levels",
                                     gen_mask: SNP_MASK,
                                     run: Box::new(|| {
-                                        let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                                        let res = x86_64::__cpuid(0x8000_001f);
 
                                         let stat = if (res.eax & (0x1 << 5)) != 0 {
                                             TestState::Pass
@@ -276,7 +276,7 @@ fn collect_tests() -> Vec<Test> {
                                         name: "Number of VMPLs",
                                         gen_mask: SNP_MASK,
                                         run: Box::new(|| {
-                                            let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                                            let res = x86_64::__cpuid(0x8000_001f);
                                             let num_vmpls = (res.ebx & 0xF000) >> 12;
 
                                             TestResult {
@@ -325,7 +325,7 @@ fn collect_tests() -> Vec<Test> {
                             name: "Physical address bit reduction",
                             gen_mask: SEV_MASK,
                             run: Box::new(|| {
-                                let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                                let res = x86_64::__cpuid(0x8000_001f);
                                 let field = (res.ebx & 0b1111_1100_0000) >> 6;
 
                                 TestResult {
@@ -340,7 +340,7 @@ fn collect_tests() -> Vec<Test> {
                             name: "C-bit location",
                             gen_mask: SEV_MASK,
                             run: Box::new(|| {
-                                let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                                let res = x86_64::__cpuid(0x8000_001f);
                                 let field = res.ebx & 0b11_1111;
 
                                 TestResult {
@@ -355,7 +355,7 @@ fn collect_tests() -> Vec<Test> {
                             name: "Number of encrypted guests supported simultaneously",
                             gen_mask: SEV_MASK,
                             run: Box::new(|| {
-                                let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                                let res = x86_64::__cpuid(0x8000_001f);
                                 let field = res.ecx;
 
                                 TestResult {
@@ -371,7 +371,7 @@ fn collect_tests() -> Vec<Test> {
                             name: "Minimum ASID value for SEV-enabled, SEV-ES disabled guest",
                             gen_mask: SEV_MASK,
                             run: Box::new(|| {
-                                let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                                let res = x86_64::__cpuid(0x8000_001f);
                                 let field = res.edx;
 
                                 TestResult {
@@ -402,7 +402,7 @@ fn collect_tests() -> Vec<Test> {
                     name: "Page flush MSR",
                     gen_mask: SEV_MASK,
                     run: Box::new(|| {
-                        let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                        let res = x86_64::__cpuid(0x8000_001f);
 
                         let msr_flag = if (res.eax & (0x1 << 2)) != 0 {
                             "ENABLED".green()

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -37,7 +37,7 @@ impl ProcessorGeneration {
     // Compare these values with the models and families of known processor generations to
     // determine which generation the current processor is a part of.
     pub(crate) fn current() -> Result<Self> {
-        let cpuid = unsafe { x86_64::__cpuid(0x8000_0001) };
+        let cpuid = x86_64::__cpuid(0x8000_0001);
 
         // Bits 31:28 are used to differentiate between Bergamo and Siena machines.
         let socket = (cpuid.ebx & 0xF0000000u32) >> 0x1C;


### PR DESCRIPTION
warning: unnecessary `unsafe` block
  --> src/processor.rs:40:21
   |
40 |         let cpuid = unsafe { x86_64::__cpuid(0x8000_0001) };
   |                     ^^^^^^ unnecessary `unsafe` block
   |
   = note: `#[warn(unused_unsafe)]` (part of `#[warn(unused)]`) on by default

warning: unnecessary `unsafe` block
   --> src/ok.rs:105:27
    |
105 |                 let res = unsafe { x86_64::__cpuid(0x0000_0000) };
    |                           ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:129:45
    |
129 | ...                   let cpuid = unsafe { x86_64::__cpuid(cpuid) };
    |                                   ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:161:35
    |
161 |                         let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                   ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:186:35
    |
186 |                         let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                   ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:211:43
    |
211 | ...                   let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                 ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:242:43
    |
242 | ...                   let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                 ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:261:51
    |
261 | ...                   let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                 ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:279:55
    |
279 | ...                   let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                 ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:328:43
    |
328 | ...                   let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                 ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:343:43
    |
343 | ...                   let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                 ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:358:43
    |
358 | ...                   let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                 ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:374:43
    |
374 | ...                   let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                 ^^^^^^ unnecessary `unsafe` block

warning: unnecessary `unsafe` block
   --> src/ok.rs:405:35
    |
405 |                         let res = unsafe { x86_64::__cpuid(0x8000_001f) };
    |                                   ^^^^^^ unnecessary `unsafe` block

warning: `snphost` (bin "snphost") generated 14 warnings