### PR TITLE
ok: add verbose option

### DIFF
--- a/docs/snphost.1.adoc
+++ b/docs/snphost.1.adoc
@@ -67,8 +67,9 @@ COMMANDS
         related capabilities on the host and emits the results.
 
  options:
-  -s, --short  Show only failures with summary counts
-  -h, --help   Show a help message.
+        -s, --short     Show only failures with summary counts
+        -v, --verbose   Show detailed test descriptions grouped by category with detected issues summary
+        -h, --help      Show a help message
 
 *snphost commit*::
 	usage: snphost commit

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,613 @@
+# Troubleshooting Guide
+
+# snphost ok - System Readiness Check Troubleshooting Guide
+
+Quick reference for diagnosing and fixing `snphost ok` test failures.
+
+## Prerequisites
+
+- Must run on baremetal host (not inside a VM)
+- Requires root/sudo privileges
+
+## Summary of SEV Requirements
+
+| Component | Minimum Version | Notes |
+|-----------|----------------|-------|
+| **Processor** | AMD EPYC 3rd Gen (Milan) | For full SEV-SNP support |
+| **SEV Firmware** | 1.51+ | Check with `snphost show version` |
+| **Linux Kernel** | 6.11+ | Or distro with SNP backport |
+| **BIOS/AGESA** | Latest from vendor | SNP support varies by BIOS version |
+
+## Common Quick Fixes
+
+| Issue | Quick Fix |
+|-------|-----------|
+| Permission denied errors | Run with root `sudo snphost ok` |
+| MSR read failed | `sudo modprobe msr` |
+| `/dev/sev` not found | `sudo modprobe ccp` (PSP driver) |
+| `/dev/kvm` errors | `sudo modprobe kvm && sudo modprobe kvm_amd` |
+
+## Test Categories
+
+| Technology | CPU Support | CPU Info | BIOS Configured | Platform Initialized | KVM Config | Compliance |
+|------------|-------------|----------|----------------------|---------------------|------------|------------|
+| **CPU & Platform** | [AMD Processor](#amd-processor)<br><br>[AMD EPYC Processor](#amd-epyc-processor) | [Physical Address Bits](#physical-address-bit-reduction)<br><br>[C-bit Position](#c-bit-position) | [Firmware Version](#firmware-version) | [/dev/sev Readable](#devsev-readable)<br><br>[/dev/sev Writable](#devsev-writable) | [KVM Support](#kvm-support) | [Memlock Limits](#memlock-limits) |
+| **SME** | [SME Support](#sme-support) | | [SME Enabled](#sme-enabled) | | | |
+| **SEV** | [SEV Support](#sev-support) | [Max Guests](#maximum-encrypted-guests)<br><br>[Page Flush MSR](#page-flush-msr-support) | [ASID Limits](#minimum-sev-only-asid) | [SEV Initialized](#sev-initialized) | [SEV Enabled in KVM](#sev-enabled-in-kvm) | |
+| **SEV-ES** | [SEV-ES Support](#sev-es-support) | | | [SEV-ES Initialized](#sev-es-initialized) | [SEV-ES Enabled in KVM](#sev-es-enabled-in-kvm) | |
+| **SEV-SNP** | [SEV-SNP Support](#sev-snp-support) | [VMPL Support](#vmpl-support--count) | [SNP Enabled](#snp-enabled)<br><br>[RMP Addresses](#rmp-addresses) | [SNP Initialized](#snp-initialized)<br><br>[RMP Initialized](#rmp-initialized) | [SEV-SNP Enabled in KVM](#sev-snp-enabled-in-kvm) | [Memory Alias Check](#memory-alias-check)<br><br>[TCB Comparison](#tcb-version-comparison) |
+
+**Column Descriptions:**
+- **CPU Support**: CPUID checks - does the processor have this feature?
+- **CPU Info**: Informational CPUID values - configuration details and limits
+- **BIOS Configured**: Check FW version & BIOS/UEFI settings
+- **Platform Initialized**: Runtime state after kernel modules load and firmware initializes
+- **KVM Config**: KVM module parameters and hypervisor readiness
+- **Compliance**: Security validations and resource limits
+
+---
+
+## CPU Support
+
+### AMD Processor
+
+**Tests:** CPU vendor is AMD
+
+**Requires:** AMD EPYC 7003 (Milan) or newer for SNP support (consumer Ryzen not supported)
+
+---
+
+### AMD EPYC Processor
+
+**Tests:** Processor is EPYC server-class CPU
+
+**Requires:** AMD EPYC 7003 (Milan) or newer for SNP support (consumer Ryzen not supported)
+
+---
+
+### SME Support
+
+**Tests:** CPU has Secure Memory Encryption hardware support (CPUID 0x8000001F, EAX bit 0)
+
+**Requires:** AMD EPYC 7001 (Naples) or newer, and at least AMD EPYC 7003 (Milan) for SNP support
+
+---
+
+### SEV Support
+
+**Tests:** CPU has SEV hardware support (CPUID 0x8000001F, EAX bit 1)
+
+**Requires:** AMD EPYC processor, and at least AMD EPYC 7003 (Milan) for SNP support
+
+---
+
+### SEV-ES Support
+
+**Tests:** CPU has SEV-ES (Encrypted State) support (CPUID 0x8000001F, EAX bit 3)
+
+**Requires:** AMD EPYC 7002 (Rome) or newer, and at least AMD EPYC 7003 (Milan) for SNP support
+
+---
+
+### SEV-SNP Support
+
+**Tests:** CPU has SEV-SNP hardware support (CPUID 0x8000001F, EAX bit 4)
+
+**Requires:** AMD EPYC 7003 (Milan) or newer
+
+---
+
+## CPU Info
+
+### Physical Address Bit Reduction
+
+**Tests:** Physical address bits lost when encryption enabled (informational)
+
+**Typical Values:** 1 or 6, depending on generation
+
+> **Example:** 52-bit physical addressing with reduction of 1 = 51 usable bits
+
+---
+
+### C-bit Position
+
+**Tests:** Page table bit position indicating encrypted page (informational)
+
+| Processor | C-bit Position |
+|-----------|----------------|
+| Milan     | 47 |
+| Genoa/Turin | 51 |
+
+---
+
+### Maximum Encrypted Guests
+
+**Tests:** Max simultaneous encrypted guests (informational)
+
+| Processor | Max Guests |
+|-----------|------------|
+| Milan | 509 / 253 |
+| Genoa/Turin | 1006 |
+
+> **Note:** Actual count depends on ASID allocation (see BIOS "SEV-ES ASID Space Limit")
+
+---
+
+### Page Flush MSR Support
+
+**Tests:** CPU supports Page Flush MSR optimization (informational, never fails)
+
+**Status:**
+- **ENABLED** (green): Optimization available
+- **DISABLED** (yellow): Uses standard cache flushing (functional but slower)
+
+> **Note:** If disabled but supported, check BIOS settings.
+
+---
+
+### VMPL Support / Count
+
+**Tests:** VM Permission Levels supported (informational)
+
+**Expected:** 4 VMPLs (VMPL0-VMPL3)
+
+> **What are VMPLs?** Four privilege levels for guest software under SEV-SNP. Unexpected values may indicate engineering sample processor.
+
+---
+
+### Minimum SEV-only ASID
+
+**Tests:** Minimum ASID for SEV-only guests (informational)
+
+**Example:** If value is 500, then:
+- ASIDs 1-499: SEV-ES/SEV-SNP guests
+- ASIDs 500-1006: SEV-only guests
+
+**Configuration:** BIOS → "SEV-ES ASID Space Limit"
+
+---
+
+## BIOS Configured
+
+### Firmware Version
+
+**Tests:** SEV firmware ≥ 1.51 (queries `/dev/sev` PLATFORM_STATUS)
+
+> **⚠️ REQUIREMENT:** Firmware version **1.51 or higher** required for SEV-SNP support
+
+**Test fails with "Invalid Firmware version: 0" (couldn't query /dev/sev):**
+```bash
+sudo snphost ok
+lsmod | grep ccp  # Check if PSP driver loaded
+sudo modprobe ccp  # Load PSP driver (creates /dev/sev)
+```
+
+**Test fails with firmware version < 1.51:**
+
+Your firmware is too old for SNP support. Firmware can be upgraded either through a BIOS/UEFI bundled upgrade provided by the OEM vendor, or by using a standalone SEV firmware file (.sbin) from the [AMD SEV Developer Documentation](https://www.amd.com/en/developer/sev.html).
+
+**To check Current Version:**
+```bash
+sudo snphost show version
+```
+
+> **Documentation References**
+> - [AMD SEV-SNP Firmware ABI Specification](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56860.pdf) - Section on firmware management
+> - [Using SEV with AMD EPYC Processors](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/tuning-guides/58207-using-sev-with-amd-epyc-processors.pdf) - AMD Tuning Guide
+> - Your system vendor's BIOS update documentation
+
+---
+
+### SME Enabled
+
+**Tests:** SME is enabled via MSR 0xC0010010 (SYSCFG), bit 23
+
+**Check:**
+```bash
+sudo snphost ok
+sudo modprobe msr
+```
+
+**Enable in BIOS:**
+1. Enter BIOS setup
+2. Navigate to **CBS > CPU Common > SMEE**
+3. Set to **Enabled**
+4. Save and reboot
+
+> **Details:** Reads Model-Specific Register (MSR) to check if Secure Memory Encryption is enabled at the system level. Requires the `msr` kernel module.
+
+---
+
+### SNP Enabled
+
+**Tests:** SEV-SNP enabled via MSR 0xC0010010 (SYSCFG), bit 24
+
+**Check:**
+```bash
+sudo snphost ok
+sudo modprobe msr
+```
+
+**Enable in BIOS:**
+1. Enter BIOS setup
+2. **CBS > CPU Common > SNP Memory Coverage** > **Enabled**
+3. **NBIO Common > SEV-SNP** > **Enabled**
+4. Save and reboot
+5. Verify: `dmesg | grep -i snp`
+
+> **Details:** Checks if SNP is enabled at the platform level through the SYSCFG MSR.
+
+---
+
+### RMP Addresses
+
+**Tests:** Reverse Map Table has valid base/end addresses (MSRs 0xC0010132, 0xC0010133)
+
+**Enable in BIOS:**
+1. Enter BIOS setup
+2. **CBS > CPU Common > SNP Memory Coverage** → **Enabled**
+3. Save and reboot
+4. Verify: `dmesg | grep -i "RMP table"`
+
+> **What is RMP?** System-wide data structure tracking memory ownership for SNP guests. Both base and end addresses must be non-zero.
+
+---
+
+## Platform Initialized
+
+### /dev/sev Readable
+
+**Tests:** `/dev/sev` device exists and readable
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| Permission denied | Run with `sudo snphost ok` |
+| Device not found | See [Why /dev/sev Doesn't Exist](#why-devsev-doesnt-exist) for detailed troubleshooting |
+
+**Quick Fix:**
+```bash
+# Load PSP driver (creates /dev/sev)
+sudo modprobe ccp
+
+# Run the test
+sudo snphost ok
+```
+
+---
+
+### /dev/sev Writable
+
+**Tests:** `/dev/sev` writable (required for firmware commands)
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| Permission denied | Run with `sudo snphost ok` |
+| Device not found | See [Why /dev/sev Doesn't Exist](#why-devsev-doesnt-exist) for detailed troubleshooting |
+| SELinux/AppArmor blocking | Check security policy denials in system logs |
+
+**Quick Fix:**
+```bash
+# Load PSP driver (creates /dev/sev)
+sudo modprobe ccp
+
+# Run the test with sudo
+sudo snphost ok
+
+# Verify device permissions
+ls -la /dev/sev  # Should show: crw------- 1 root root
+```
+
+---
+
+### SEV Initialized
+
+**Tests:** SEV platform is in "Initialized" or "Working" state
+
+**Fix:**
+
+If `sudo snphost ok` fails on this test, try enabling SEV in KVM, then verify kernel logs:
+```bash
+sudo modprobe kvm_amd sev=1
+dmesg | grep -i sev
+```
+
+> **Pass States:** "Initialized" (no guests running) or "Working" (guests active)
+
+---
+
+### SEV-ES Initialized
+
+**Tests:** SEV-ES firmware initialized (platform status flags bit 8)
+
+**Fix:**
+
+If `sudo snphost ok` fails on this test, try enabling SEV in KVM, then verify kernel logs:
+```bash
+sudo modprobe kvm_amd sev=1 sev-es=1
+dmesg | grep -i sev-es
+cat /sys/module/kvm_amd/parameters/sev_es  # Should show Y or 1
+```
+
+---
+
+### SNP Initialized
+
+**Tests:** SNP firmware is in INIT state (SNP_PLATFORM_STATUS state field = 1)
+
+**Fix:**
+
+If `sudo snphost ok` fails on this test, try enabling SEV in KVM, then verify kernel logs:
+```bash
+uname -r  # Check kernel version (need 6.11+ or distro with SNP backport)
+grep CONFIG_KVM_AMD_SEV /boot/config-$(uname -r)  # Must be y or m
+sudo modprobe kvm_amd sev_snp=1
+dmesg | grep -i sev-snp
+```
+
+> **KERNEL REQUIREMENT**
+> - Linux **6.11+** mainline, OR
+> - Distribution with SNP backport (Ubuntu 24.04+, RHEL 9.4+, etc.)
+> - Kernel config: `CONFIG_KVM_AMD_SEV=y`
+
+> **Note:** Also requires BIOS to allocate RMP memory (SNP Memory Coverage enabled)
+
+---
+
+### RMP Initialized
+
+**Tests:** RMP table initialized by SNP firmware (IS_RMP_INIT bit)
+
+**Verify:**
+```bash
+grep CONFIG_KVM_AMD_SEV /boot/config-$(uname -r)  # Must be y
+dmesg | grep -E "RMP|SNP|SEV"
+```
+
+**Fix:** Reboot if firmware was recently updated
+
+---
+
+## KVM Config
+
+### KVM Support
+
+**Tests:** KVM hypervisor available and functional (opens `/dev/kvm`, queries API)
+
+**Check:**
+```bash
+sudo snphost ok
+sudo modprobe kvm && sudo modprobe kvm_amd
+ls -la /dev/kvm
+dmesg | grep -i kvm
+```
+
+**Check Kernel Configuration:**
+```bash
+# Check if KVM modules are available
+grep -E "CONFIG_KVM|CONFIG_KVM_AMD" /boot/config-$(uname -r)
+
+# Should show:
+# CONFIG_KVM=y (or =m)
+# CONFIG_KVM_AMD=y (or =m)
+```
+
+**Enable in BIOS:**
+1. Enable **SVM (Secure Virtual Machine)** in BIOS
+2. Typically under **CBS > CPU Common > SVM Mode** or **Advanced > CPU Configuration**
+3. Save and reboot
+
+> **Kernel Requirements:**
+> - `CONFIG_KVM=y` or `=m`
+> - `CONFIG_KVM_AMD=y` or `=m`
+> - If missing, kernel recompile or distro upgrade needed
+
+---
+
+### SEV Enabled in KVM
+
+**Tests:** `kvm_amd` module has SEV support enabled
+
+**Check:**
+```bash
+cat /sys/module/kvm_amd/parameters/sev  # Should show Y or 1
+```
+
+**Enable:**
+```bash
+# Temporary
+sudo modprobe -r kvm_amd && sudo modprobe kvm_amd sev=1
+
+# Persistent
+echo "options kvm_amd sev=1 sev-es=1 sev-snp=1" | sudo tee /etc/modprobe.d/kvm.conf
+sudo modprobe -r kvm_amd && sudo modprobe kvm_amd
+```
+
+---
+
+### SEV-ES Enabled in KVM
+
+**Tests:** `kvm_amd` module has SEV-ES support enabled
+
+**Enable:** Same as [SEV Enabled in KVM](#sev-enabled-in-kvm), ensure `sev-es=1` parameter
+
+---
+
+### SEV-SNP Enabled in KVM
+
+**Tests:** `kvm_amd` module has SEV-SNP support enabled
+
+**Check:**
+```bash
+cat /sys/module/kvm_amd/parameters/sev_snp  # Should show Y or 1
+```
+
+**Check SNP Support:**
+```bash
+# Check kernel version
+uname -r  # Need 6.11+ or distro with backport
+
+# Check if sev_snp parameter exists
+ls /sys/module/kvm_amd/parameters/sev_snp
+
+# Check kernel config
+grep CONFIG_KVM_AMD_SEV /boot/config-$(uname -r)  # Must be 'y'
+```
+
+**Enable:**
+```bash
+# Persistent configuration
+echo "options kvm_amd sev=1 sev-es=1 sev-snp=1" | sudo tee /etc/modprobe.d/kvm.conf
+sudo modprobe -r kvm_amd && sudo modprobe kvm_amd
+```
+
+> **If parameter file doesn't exist:** Kernel lacks SNP support - upgrade kernel or use supported distro.
+
+---
+
+## Compliance
+
+### Memlock Limits
+
+**Tests:** `RLIMIT_MEMLOCK` soft and hard limits (informational)
+
+**Why It Matters:** SEV-SNP guests require entire memory pinned in RAM. Low memlock limit causes guest launch failures.
+
+**Recommended Configuration:**
+
+```bash
+# For user sessions
+echo "* - memlock unlimited" | sudo tee -a /etc/security/limits.conf
+
+# For systemd services (e.g., libvirtd)
+# Add to service unit:
+[Service]
+LimitMEMLOCK=infinity
+```
+
+**Verify:** `ulimit -l`
+
+**Guideline:** memlock ≥ (total guest RAM) + (256 MiB per guest overhead)
+
+---
+
+### Memory Alias Check
+
+**Tests:** Memory aliasing detection completed, no aliasing detected (security mitigation for CVE-2024-21944)
+
+**Update Required:**
+1. Update SEV firmware to latest version
+2. Update BIOS/AGESA per [AMD-SB-3015](https://www.amd.com/en/resources/product-security/bulletin/amd-sb-3015.html)
+3. Reboot (check runs during SNP init)
+
+> **Security Advisory:** Addresses CVE-2024-21944 (AMD-SB-3015). Alias check runs during SNP initialization.
+
+---
+
+### TCB Version Comparison
+
+**Tests:** Platform TCB matches Reported TCB (both from SNP_PLATFORM_STATUS)
+
+**Check:**
+```bash
+sudo snphost ok
+```
+
+**Fix mismatch:**
+
+```bash
+# Option 1: Commit current TCB (irreversible, prevents rollback)
+sudo snphost commit
+
+# Option 2: Set reported TCB to match platform
+sudo snphost config set-reported-tcb
+```
+
+> **⚠️ WARNING**
+> `snphost commit` is **irreversible** - it permanently prevents rollback to older firmware/microcode versions.
+
+**TCB Components:**
+| Component | Description |
+|-----------|-------------|
+| Microcode | CPU microcode version |
+| SNP | SNP firmware security version |
+| TEE | Trusted Execution Environment version |
+| Boot Loader | PSP bootloader security version |
+| FMC | Firmware Management Component (Turin+ only; None on older systems) |
+
+**Expected Mismatch:** If you intentionally set lower Reported TCB for backwards compatibility.
+
+---
+
+## Why /dev/sev Doesn't Exist
+
+If `/dev/sev` is missing, multiple tests will fail (firmware version, SEV/SNP initialized, TCB comparison, etc.). Use this table to identify and fix the root cause:
+
+| Cause | How to Detect | Fix |
+|-------|---------------|-----|
+| **CCP kernel module not loaded** | `lsmod \| grep ccp` shows nothing | `sudo modprobe ccp` |
+| **Running inside a VM** | `systemd-detect-virt` returns something other than "none" | Must run on baremetal host |
+| **Kernel missing CCP/PSP config** | `grep CONFIG_CRYPTO_DEV_CCP /boot/config-$(uname -r)` is missing or `=n` | Upgrade kernel or recompile with CCP support |
+| **SEV disabled in BIOS** | PSP won't initialize SEV subsystem | Enable SEV in BIOS (CBS > CPU Common) |
+| **IOMMU not enabled** | SEV requires IOMMU | Enable IOMMU in BIOS; ensure `iommu=pt` kernel param |
+| **PSP firmware issue** | `dmesg \| grep -i psp` shows errors | Update BIOS (PSP firmware is bundled with BIOS) |
+| **Kernel boot params missing** | `cat /proc/cmdline` | May need `mem_encrypt=on` on older kernels |
+| **Kernel too old** | `uname -r` | Need 4.16+ for basic SEV, 6.11+ for SNP |
+
+**Quick diagnostic:**
+```bash
+# 1. Check if running on baremetal
+systemd-detect-virt               # Must output "none"
+
+# 2. Check if CCP module is loaded
+lsmod | grep ccp
+
+# 3. Load CCP module if missing
+sudo modprobe ccp
+
+# 4. Check kernel configuration
+grep -E "CONFIG_CRYPTO_DEV_CCP|CONFIG_KVM_AMD_SEV" /boot/config-$(uname -r)
+
+# 5. Check for PSP/CCP driver errors
+dmesg | grep -iE "ccp|psp|sev"
+```
+
+> **Note:** If `/dev/sev` exists but tests still fail with "unable to open /dev/sev", the issue is file permissions — run with `sudo`.
+
+---
+
+## BIOS Configuration Reference
+
+Required BIOS/UEFI settings for SEV-SNP (paths vary by OEM):
+
+| Setting | Location | Value | Purpose |
+|---------|----------|-------|---------|
+| **SMEE** | CBS > CPU Common | Enabled | Enable memory encryption |
+| **SNP Memory Coverage** | CBS > CPU Common | Enabled | Allocate RMP memory |
+| **SEV-SNP** | NBIO Common | Enabled | Enable SNP feature |
+| **SVM** | CBS > CPU Common | Enabled | Enable virtualization |
+| **IOMMU** | NBIO Common | Enabled | I/O memory management |
+| **SEV-ES ASID Space Limit Control** | CBS > CPU Common | Manual | Control ASID allocation |
+| **SEV-ES ASID Space Limit** | CBS > CPU Common | Custom | Split ASIDs between SEV-only and SEV-ES/SNP |
+
+---
+
+## Additional Resources
+
+### AMD Official Documentation
+- [SEV-SNP Firmware ABI Specification](https://docs.amd.com/api/khub/documents/x_tYkgJNtfpvwPq45NrSQ/content)
+- [AMD SEV Developer Resources](https://www.amd.com/en/developer/sev.html)
+- [Using SEV with AMD EPYC Processors - Tuning Guide](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/tuning-guides/58207-using-sev-with-amd-epyc-processors.pdf)
+
+### Linux Kernel Documentation
+- [AMD Memory Encryption Documentation](https://docs.kernel.org/arch/x86/amd-memory-encryption.html)
+- [KVM AMD Memory Encryption](https://docs.kernel.org/virt/kvm/x86/amd-memory-encryption.html)
+
+### Community Resources
+- [AMDESE/AMDSEV GitHub Repository](https://github.com/AMDESE/AMDSEV)
+- [Ubuntu: Confidential Computing with AMD](https://documentation.ubuntu.com/server/how-to/virtualisation/sev-snp/)
+- [libvirt: Launch Security with AMD SEV](https://libvirt.org/kbase/launch_security_sev.html)
+
+### Security Advisories
+- [AMD Security Bulletin AMD-SB-3015](https://www.amd.com/en/resources/product-security/bulletin/amd-sb-3015.html) - Memory alias check (CVE-2024-21944)

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -20,6 +20,7 @@ use msru::{Accessor, Msr};
 enum Verbosity {
     Default,
     Short,
+    Verbose,
 }
 
 #[derive(Args, Clone)]
@@ -27,16 +28,71 @@ pub struct Ok {
     /// Show only failures with summary counts
     #[arg(short, long)]
     short: bool,
+
+    /// Show detailed test descriptions grouped by category with detected issues summary
+    #[arg(short, long, conflicts_with = "short")]
+    verbose: bool,
 }
 
 impl Ok {
     fn verbosity(&self) -> Verbosity {
-        if self.short {
+        if self.verbose {
+            Verbosity::Verbose
+        } else if self.short {
             Verbosity::Short
         } else {
             Verbosity::Default
         }
     }
+}
+
+/// Category for grouping tests in verbose output
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TestCategory {
+    CpuSupport,
+    CpuInfo,
+    BiosConfigured,
+    PlatformInitialized,
+    KvmConfig,
+    Compliance,
+}
+
+impl fmt::Display for TestCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TestCategory::CpuSupport => write!(f, "CPU Support"),
+            TestCategory::CpuInfo => write!(f, "CPU Info"),
+            TestCategory::BiosConfigured => write!(f, "BIOS Configured"),
+            TestCategory::PlatformInitialized => write!(f, "Platform Initialized"),
+            TestCategory::KvmConfig => write!(f, "KVM Config"),
+            TestCategory::Compliance => write!(f, "Compliance"),
+        }
+    }
+}
+
+/// Metadata for a test: category, description, and fix hint.
+#[derive(Clone, Copy)]
+struct TestMetadata {
+    category: TestCategory,
+    description: &'static str,
+    fix_hint: &'static str,
+}
+
+const MSR_HINT: &str = "Load MSR kernel module: sudo modprobe msr";
+const SUDO_HINT: &str = "Run with sudo: sudo snphost ok";
+
+/// Returns the appropriate fix hint for a failed test, overriding
+/// the metadata hint for access/module issues.
+fn effective_hint(meta: &TestMetadata, message: &Option<String>) -> &'static str {
+    if let Some(m) = message {
+        if m.contains("MSR read failed") || m.contains("Failed to read the desired MSR") {
+            return MSR_HINT;
+        }
+        if m.contains("unable to open /dev/sev") || m.contains("Permission denied") {
+            return SUDO_HINT;
+        }
+    }
+    meta.fix_hint
 }
 
 type TestFn = dyn Fn() -> TestResult;
@@ -50,6 +106,7 @@ struct Test {
     name: &'static str,
     gen_mask: usize,
     run: Box<TestFn>,
+    meta: TestMetadata,
     sub: Vec<Test>,
 }
 
@@ -61,6 +118,7 @@ struct TestResult {
 
 struct TestResultNode {
     result: TestResult,
+    meta: TestMetadata,
     sub: Vec<TestResultNode>,
 }
 
@@ -147,6 +205,11 @@ fn collect_tests() -> Vec<Test> {
                     mesg: None,
                 }
             }),
+            meta: TestMetadata {
+                category: TestCategory::CpuSupport,
+                description: "Checks CPU vendor string via CPUID is \"AuthenticAMD\"",
+                fix_hint: "Requires AMD processor",
+            },
             sub: vec![
                 Test {
                     name: "Microcode support",
@@ -181,6 +244,11 @@ fn collect_tests() -> Vec<Test> {
                             mesg: None,
                         }
                     }),
+                    meta: TestMetadata {
+                        category: TestCategory::CpuSupport,
+                        description: "Verifies processor brand string contains \"EPYC\" (server-class CPU required)",
+                        fix_hint: "Need EPYC server-class CPU",
+                    },
                     sub: vec![],
                 },
                 Test {
@@ -201,10 +269,20 @@ fn collect_tests() -> Vec<Test> {
                             mesg: None,
                         }
                     }),
+                    meta: TestMetadata {
+                        category: TestCategory::CpuSupport,
+                        description: "Checks CPUID 0x8000001F EAX bit 0 for SME hardware support",
+                        fix_hint: "Need EPYC 7001+",
+                    },
                     sub: vec![Test {
                         name: "SME",
                         gen_mask: SEV_MASK,
                         run: Box::new(sme_test),
+                        meta: TestMetadata {
+                            category: TestCategory::BiosConfigured,
+                            description: "Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level",
+                            fix_hint: "BIOS: CBS > CPU Common > SMEE. Run: sudo modprobe msr",
+                        },
                         sub: vec![],
                     }],
                 },
@@ -226,11 +304,21 @@ fn collect_tests() -> Vec<Test> {
                             mesg: None,
                         }
                     }),
+                    meta: TestMetadata {
+                        category: TestCategory::CpuSupport,
+                        description: "Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support",
+                        fix_hint: "Need EPYC with SEV",
+                    },
                     sub: vec![
                         Test {
                             name: "SEV Firmware Version",
                             gen_mask: SNP_MASK,
                             run: Box::new(|| sev_ioctl(SevStatusTests::Firmware)),
+                            meta: TestMetadata {
+                                category: TestCategory::BiosConfigured,
+                                description: "Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)",
+                                fix_hint: "Run with sudo. For SNP support, update BIOS for firmware >= 1.51",
+                            },
                             sub: vec![],
                         },
                         Test {
@@ -251,10 +339,20 @@ fn collect_tests() -> Vec<Test> {
                                     mesg: None,
                                 }
                             }),
+                            meta: TestMetadata {
+                                category: TestCategory::CpuSupport,
+                                description: "Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support",
+                                fix_hint: "Need EPYC 7002+",
+                            },
                             sub: vec![Test {
                                 name: "SEV-ES initialized",
                                 gen_mask: ES_MASK,
                                 run: Box::new(|| sev_ioctl(SevStatusTests::SevEs)),
+                                meta: TestMetadata {
+                                    category: TestCategory::PlatformInitialized,
+                                    description: "Queries SEV platform status flags bit 8 for SEV-ES initialization",
+                                    fix_hint: "Run with sudo. Run: sudo modprobe kvm_amd sev=1 sev-es=1",
+                                },
                                 sub: vec![],
                             }],
                         },
@@ -262,6 +360,11 @@ fn collect_tests() -> Vec<Test> {
                             name: "SEV initialized",
                             gen_mask: SNP_MASK,
                             run: Box::new(|| sev_ioctl(SevStatusTests::Sev)),
+                            meta: TestMetadata {
+                                category: TestCategory::PlatformInitialized,
+                                description: "Queries SEV platform status state field (must be Initialized or Working)",
+                                fix_hint: "Run with sudo. Run: sudo modprobe kvm_amd sev=1",
+                            },
                             sub: vec![],
                         },
                         Test {
@@ -282,6 +385,11 @@ fn collect_tests() -> Vec<Test> {
                                     mesg: None,
                                 }
                             }),
+                            meta: TestMetadata {
+                                category: TestCategory::CpuSupport,
+                                description: "Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support",
+                                fix_hint: "Need EPYC 7003+",
+                            },
                             sub: vec![
                                 Test {
                                     name: "VM Permission Levels",
@@ -301,6 +409,11 @@ fn collect_tests() -> Vec<Test> {
                                             mesg: None,
                                         }
                                     }),
+                                    meta: TestMetadata {
+                                        category: TestCategory::CpuSupport,
+                                        description: "Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support",
+                                        fix_hint: "Update BIOS to latest version",
+                                    },
                                     sub: vec![Test {
                                         name: "Number of VMPLs",
                                         gen_mask: SNP_MASK,
@@ -314,6 +427,11 @@ fn collect_tests() -> Vec<Test> {
                                                 mesg: Some(format!("{}", num_vmpls)),
                                             }
                                         }),
+                                        meta: TestMetadata {
+                                            category: TestCategory::CpuInfo,
+                                            description: "Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)",
+                                            fix_hint: "Informational, no action needed",
+                                        },
                                         sub: vec![],
                                     }],
                                 },
@@ -321,29 +439,54 @@ fn collect_tests() -> Vec<Test> {
                                     name: "SEV-SNP",
                                     gen_mask: SNP_MASK,
                                     run: Box::new(snp_test),
+                                    meta: TestMetadata {
+                                        category: TestCategory::BiosConfigured,
+                                        description: "Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level",
+                                        fix_hint: "BIOS: CBS > CPU Common > SNP Memory Coverage. Run: sudo modprobe msr",
+                                    },
                                     sub: vec![],
                                 },
                                 Test {
                                     name: "SNP initialized",
                                     gen_mask: SNP_MASK,
                                     run: Box::new(|| snp_ioctl(SnpStatusTest::Snp)),
+                                    meta: TestMetadata {
+                                        category: TestCategory::PlatformInitialized,
+                                        description: "Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)",
+                                        fix_hint: "Run with sudo. Need kernel 6.11+. Run: sudo modprobe kvm_amd sev_snp=1. Update BIOS for firmware >= 1.51 and reboot.",
+                                    },
                                     sub: vec![
                                         Test {
                                             name: "Read RMP tables",
                                             gen_mask: SNP_MASK,
                                             run: Box::new(get_rmp_address),
+                                            meta: TestMetadata {
+                                                category: TestCategory::BiosConfigured,
+                                                description: "Reads MSRs 0xC0010132 and 0xC0010133 for RMP base/end addresses",
+                                                fix_hint: "Enable SNP Memory Coverage in BIOS. Run: sudo modprobe msr",
+                                            },
                                             sub: vec![],
                                         },
                                         Test {
                                             name: "RMP table initialized",
                                             gen_mask: SNP_MASK,
                                             run: Box::new(|| snp_ioctl(SnpStatusTest::Rmp)),
+                                            meta: TestMetadata {
+                                                category: TestCategory::PlatformInitialized,
+                                                description: "Queries SNP platform status IS_RMP_INIT bit",
+                                                fix_hint: "Run with sudo. Need CONFIG_KVM_AMD_SEV=y. Reboot if firmware updated",
+                                            },
                                             sub: vec![],
                                         },
                                         Test {
                                             name: "Alias check",
                                             gen_mask: SNP_MASK,
                                             run: Box::new(|| snp_ioctl(SnpStatusTest::AliasCheck)),
+                                            meta: TestMetadata {
+                                                category: TestCategory::Compliance,
+                                                description: "Queries SNP platform status ALIAS_CHECK_COMPLETE bit (CVE-2024-21944 mitigation)",
+                                                fix_hint: "Update firmware/BIOS per AMD-SB-3015. Reboot required",
+                                            },
                                             sub: vec![],
                                         },
                                     ],
@@ -363,6 +506,11 @@ fn collect_tests() -> Vec<Test> {
                                     mesg: Some(format!("{}", field)),
                                 }
                             }),
+                            meta: TestMetadata {
+                                category: TestCategory::CpuInfo,
+                                description: "Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value",
+                                fix_hint: "Informational, no action needed",
+                            },
                             sub: vec![],
                         },
                         Test {
@@ -378,6 +526,11 @@ fn collect_tests() -> Vec<Test> {
                                     mesg: Some(format!("{}", field)),
                                 }
                             }),
+                            meta: TestMetadata {
+                                category: TestCategory::CpuInfo,
+                                description: "Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables",
+                                fix_hint: "Informational, no action needed",
+                            },
                             sub: vec![],
                         },
                         Test {
@@ -394,6 +547,11 @@ fn collect_tests() -> Vec<Test> {
                                     mesg: Some(format!("{}", field)),
                                 }
                             }),
+                            meta: TestMetadata {
+                                category: TestCategory::CpuInfo,
+                                description: "Reads CPUID 0x8000001F ECX for maximum encrypted guest count",
+                                fix_hint: "Informational, no action needed",
+                            },
                             sub: vec![],
                         },
                         Test {
@@ -411,18 +569,33 @@ fn collect_tests() -> Vec<Test> {
                                     mesg: Some(format!("{}", field)),
                                 }
                             }),
+                            meta: TestMetadata {
+                                category: TestCategory::CpuInfo,
+                                description: "Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value",
+                                fix_hint: "Informational, no action needed",
+                            },
                             sub: vec![],
                         },
                         Test {
                             name: "/dev/sev readable",
                             gen_mask: SEV_MASK,
                             run: Box::new(dev_sev_r),
+                            meta: TestMetadata {
+                                category: TestCategory::PlatformInitialized,
+                                description: "Attempts to open /dev/sev device for reading",
+                                fix_hint: "Run with sudo. Run: sudo modprobe ccp. Must be baremetal",
+                            },
                             sub: vec![],
                         },
                         Test {
                             name: "/dev/sev writable",
                             gen_mask: SEV_MASK,
                             run: Box::new(dev_sev_w),
+                            meta: TestMetadata {
+                                category: TestCategory::PlatformInitialized,
+                                description: "Attempts to open /dev/sev device for writing",
+                                fix_hint: "Run with sudo. Must be baremetal",
+                            },
                             sub: vec![],
                         },
                     ],
@@ -458,6 +631,11 @@ fn collect_tests() -> Vec<Test> {
                             mesg: None,
                         }
                     }),
+                    meta: TestMetadata {
+                        category: TestCategory::CpuInfo,
+                        description: "Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support",
+                        fix_hint: "Informational, no action needed",
+                    },
                     sub: vec![],
                 },
             ],
@@ -466,23 +644,43 @@ fn collect_tests() -> Vec<Test> {
             name: "KVM Support",
             gen_mask: SEV_MASK,
             run: Box::new(has_kvm_support),
+            meta: TestMetadata {
+                category: TestCategory::KvmConfig,
+                description: "Opens /dev/kvm and queries KVM API version via ioctl",
+                fix_hint: "Run with sudo. Run: sudo modprobe kvm kvm_amd. Enable SVM in BIOS",
+            },
             sub: vec![
                 Test {
                     name: "SEV enabled in KVM",
                     gen_mask: SEV_MASK,
                     run: Box::new(|| sev_enabled_in_kvm(SevGeneration::Sev)),
+                    meta: TestMetadata {
+                        category: TestCategory::KvmConfig,
+                        description: "Reads /sys/module/kvm_amd/parameters/sev for \"1\" or \"Y\"",
+                        fix_hint: "Temp: sudo modprobe kvm_amd sev=1. Persist: echo 'options kvm_amd sev=1' | sudo tee /etc/modprobe.d/kvm.conf",
+                    },
                     sub: vec![],
                 },
                 Test {
                     name: "SEV-ES enabled in KVM",
                     gen_mask: ES_MASK,
                     run: Box::new(|| sev_enabled_in_kvm(SevGeneration::Es)),
+                    meta: TestMetadata {
+                        category: TestCategory::KvmConfig,
+                        description: "Reads /sys/module/kvm_amd/parameters/sev_es for \"1\" or \"Y\"",
+                        fix_hint: "Temp: sudo modprobe kvm_amd sev-es=1. Persist: echo 'options kvm_amd sev-es=1' | sudo tee /etc/modprobe.d/kvm.conf",
+                    },
                     sub: vec![],
                 },
                 Test {
                     name: "SEV-SNP enabled in KVM",
                     gen_mask: SNP_MASK,
                     run: Box::new(|| sev_enabled_in_kvm(SevGeneration::Snp)),
+                    meta: TestMetadata {
+                        category: TestCategory::KvmConfig,
+                        description: "Reads /sys/module/kvm_amd/parameters/sev_snp for \"1\" or \"Y\"",
+                        fix_hint: "Temp: sudo modprobe kvm_amd sev_snp=1. Persist: echo 'options kvm_amd sev_snp=1' | sudo tee /etc/modprobe.d/kvm.conf. Need kernel 6.11+",
+                    },
                     sub: vec![],
                 },
             ],
@@ -491,12 +689,22 @@ fn collect_tests() -> Vec<Test> {
             name: "memlock limit",
             gen_mask: SEV_MASK,
             run: Box::new(memlock_rlimit),
+            meta: TestMetadata {
+                category: TestCategory::Compliance,
+                description: "Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall",
+                fix_hint: "Set memlock unlimited in /etc/security/limits.conf",
+            },
             sub: vec![],
         },
         Test {
             name: "Compare TCB values",
             gen_mask: SNP_MASK,
             run: Box::new(|| snp_ioctl(SnpStatusTest::Tcb)),
+            meta: TestMetadata {
+                category: TestCategory::Compliance,
+                description: "Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS",
+                fix_hint: "Run: sudo snphost commit or sudo snphost config set (with args)",
+            },
             sub: vec![],
         },
     ];
@@ -516,6 +724,7 @@ pub fn cmd(quiet: bool, args: Ok) -> Result<()> {
         match verbosity {
             Verbosity::Default => render_default(&results, 0),
             Verbosity::Short => render_short(&results),
+            Verbosity::Verbose => render_verbose(&results),
         }
     }
 
@@ -523,9 +732,15 @@ pub fn cmd(quiet: bool, args: Ok) -> Result<()> {
     if passed {
         Ok(())
     } else {
-        Err(anyhow::anyhow!(
-            "One or more tests in snphost ok reported a failure"
-        ))
+        let msg = match verbosity {
+            Verbosity::Verbose => {
+                "One or more tests in snphost ok reported a failure"
+            }
+            Verbosity::Default | Verbosity::Short => {
+                "One or more tests in snphost ok reported a failure. Run with --verbose for detailed troubleshooting steps"
+            }
+        };
+        Err(anyhow::anyhow!(msg))
     }
 }
 
@@ -546,7 +761,11 @@ fn run_test(tests: &[Test], mask: usize) -> Vec<TestResultNode> {
                 TestState::Skip => unreachable!(),
             };
 
-            TestResultNode { result: res, sub }
+            TestResultNode {
+                result: res,
+                meta: t.meta,
+                sub,
+            }
         };
 
         results.push(node);
@@ -562,6 +781,7 @@ fn create_skip_node(test: &Test) -> TestResultNode {
             stat: TestState::Skip,
             mesg: None,
         },
+        meta: test.meta,
         sub: create_skip_nodes(&test.sub),
     }
 }
@@ -629,6 +849,89 @@ fn render_short(results: &[TestResultNode]) {
     );
     if failed.is_empty() {
         println!("{}", "All tests passed.".green());
+    }
+}
+
+fn render_verbose(results: &[TestResultNode]) {
+    let categories = [
+        TestCategory::CpuSupport,
+        TestCategory::CpuInfo,
+        TestCategory::BiosConfigured,
+        TestCategory::PlatformInitialized,
+        TestCategory::KvmConfig,
+        TestCategory::Compliance,
+    ];
+
+    // Flatten the tree structure into a list
+    let mut all_nodes = Vec::new();
+    flatten_nodes(results, &mut all_nodes);
+
+    // Filter out skipped tests
+    let all_nodes: Vec<_> = all_nodes
+        .into_iter()
+        .filter(|node| node.result.stat != TestState::Skip)
+        .collect();
+
+    for cat in &categories {
+        let cat_entries: Vec<_> = all_nodes
+            .iter()
+            .filter(|node| node.meta.category == *cat)
+            .collect();
+
+        if cat_entries.is_empty() {
+            continue;
+        }
+
+        println!("\n=== {} ===", cat);
+        for node in cat_entries {
+            let status_colored = match node.result.stat {
+                TestState::Pass => format!("{}", "PASS".green()),
+                TestState::Fail => format!("{}", "FAIL".red()),
+                TestState::Skip => format!("{}", "SKIP".yellow()),
+            };
+            let msg = match &node.result.mesg {
+                Some(m) => {
+                    let indented = m.replace('\n', "\n             ");
+                    format!(": {}", indented.trim())
+                }
+                None => String::new(),
+            };
+            println!("  [ {:^4} ] {}{}", status_colored, node.result.name, msg);
+            if !node.meta.description.is_empty() {
+                println!("           {}", node.meta.description);
+            }
+            let hint_str = effective_hint(&node.meta, &node.result.mesg);
+            if node.result.stat == TestState::Fail && !hint_str.is_empty() {
+                println!("           {} {}", "Recommended:".yellow(), hint_str);
+            }
+        }
+    }
+
+    // Collect failed tests
+    let failed_nodes: Vec<_> = all_nodes
+        .iter()
+        .filter(|node| node.result.stat == TestState::Fail)
+        .collect();
+
+    if !failed_nodes.is_empty() {
+        println!("\n{}", "=== DETECTED ISSUES ===".red());
+        for (i, node) in failed_nodes.iter().enumerate() {
+            let hint_str = effective_hint(&node.meta, &node.result.mesg);
+            println!("  {}. {} [FAIL]", i + 1, node.result.name);
+            if !hint_str.is_empty() {
+                println!("     {} {}", "Hint:".blue(), hint_str);
+            }
+        }
+        println!();
+    } else {
+        println!("\n{}", "No issues detected.".green());
+    }
+}
+
+fn flatten_nodes<'a>(results: &'a [TestResultNode], output: &mut Vec<&'a TestResultNode>) {
+    for node in results {
+        output.push(node);
+        flatten_nodes(&node.sub, output);
     }
 }
 

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -39,17 +39,6 @@ impl Ok {
     }
 }
 
-struct TestResultEntry<'a> {
-    test: &'a Test,
-    message: Option<String>,
-}
-
-struct TestResults<'a> {
-    passed: Vec<TestResultEntry<'a>>,
-    failed: Vec<TestResultEntry<'a>>,
-    skipped: Vec<TestResultEntry<'a>>,
-}
-
 type TestFn = dyn Fn() -> TestResult;
 
 // SEV generation-specific bitmasks.
@@ -68,6 +57,11 @@ struct TestResult {
     name: String,
     stat: TestState,
     mesg: Option<String>,
+}
+
+struct TestResultNode {
+    result: TestResult,
+    sub: Vec<TestResultNode>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -515,25 +509,17 @@ const INDENT: usize = 2;
 pub fn cmd(quiet: bool, args: Ok) -> Result<()> {
     let tests = collect_tests();
     let verbosity = args.verbosity();
-    let suppress_print = quiet || verbosity != Verbosity::Default;
 
-    let mut results = TestResults {
-        passed: Vec::new(),
-        failed: Vec::new(),
-        skipped: Vec::new(),
-    };
-    let passed = run_test(
-        &tests,
-        0,
-        suppress_print,
-        SEV_MASK | ES_MASK | SNP_MASK,
-        &mut results,
-    );
+    let results = run_test(&tests, SEV_MASK | ES_MASK | SNP_MASK);
 
-    if !quiet && verbosity == Verbosity::Short {
-        render_short(&results);
+    if !quiet {
+        match verbosity {
+            Verbosity::Default => render_default(&results, 0),
+            Verbosity::Short => render_short(&results),
+        }
     }
 
+    let passed = all_passed(&results);
     if passed {
         Ok(())
     } else {
@@ -543,146 +529,122 @@ pub fn cmd(quiet: bool, args: Ok) -> Result<()> {
     }
 }
 
-fn run_test<'a>(
-    tests: &'a [Test],
-    level: usize,
-    quiet: bool,
-    mask: usize,
-    results: &mut TestResults<'a>,
-) -> bool {
-    let mut passed = true;
+fn run_test(tests: &[Test], mask: usize) -> Vec<TestResultNode> {
+    let mut results = Vec::new();
 
     for t in tests {
-        // Skip tests that aren't included in the specified generation.
-        if (t.gen_mask & mask) != t.gen_mask {
-            test_gen_not_included(t, level, quiet);
-            accumulate_skip(std::slice::from_ref(t), results);
-            continue;
-        }
+        let node = if (t.gen_mask & mask) != t.gen_mask {
+            // Test doesn't match generation mask - skip it and all children
+            create_skip_node(t)
+        } else {
+            // Run the test
+            let res = (t.run)();
 
-        let res = (t.run)();
-        emit_result(&res, level, quiet);
-        let entry = TestResultEntry {
-            test: t,
-            message: res.mesg.clone(),
-        };
-        match res.stat {
-            TestState::Pass => {
-                results.passed.push(entry);
-                if !run_test(&t.sub, level + INDENT, quiet, mask, results) {
-                    passed = false;
-                }
-            }
-            TestState::Fail => {
-                results.failed.push(entry);
-                passed = false;
-                emit_skip(&t.sub, level + INDENT, quiet);
-                accumulate_skip(&t.sub, results);
-            }
-            // Skipped tests are marked as skip before recursing. They are just emitted and not actually processed.
-            TestState::Skip => unreachable!(),
-        }
-    }
-
-    passed
-}
-
-fn accumulate_skip<'a>(tests: &'a [Test], results: &mut TestResults<'a>) {
-    for t in tests {
-        results.skipped.push(TestResultEntry {
-            test: t,
-            message: None,
-        });
-        accumulate_skip(&t.sub, results);
-    }
-}
-
-fn render_short(results: &TestResults) {
-    if !results.failed.is_empty() {
-        println!("{}", "Failures:".red());
-        for e in &results.failed {
-            let msg = match &e.message {
-                Some(m) => format!(": {}", m),
-                None => String::new(),
+            let sub = match res.stat {
+                TestState::Pass => run_test(&t.sub, mask),
+                TestState::Fail => create_skip_nodes(&t.sub),
+                TestState::Skip => unreachable!(),
             };
-            println!("[ {:^4} ] - {}{}", "FAIL".red(), e.test.name, msg);
-        }
+
+            TestResultNode { result: res, sub }
+        };
+
+        results.push(node);
     }
 
-    if !results.skipped.is_empty() {
-        println!("\n{}:", "SKIPPED".yellow());
-        for s in &results.skipped {
-            println!("[ {:^4} ] - {}", "SKIP".yellow(), s.test.name);
-        }
-    }
+    results
+}
 
-    let total = results.passed.len() + results.failed.len() + results.skipped.len();
-    println!(
-        "\n{} tests: {} passed, {} failed, {} skipped",
-        total,
-        results.passed.len(),
-        results.failed.len(),
-        results.skipped.len(),
-    );
-    if results.failed.is_empty() {
-        println!("{}", "All tests passed.".green());
+fn create_skip_node(test: &Test) -> TestResultNode {
+    TestResultNode {
+        result: TestResult {
+            name: test.name.to_string(),
+            stat: TestState::Skip,
+            mesg: None,
+        },
+        sub: create_skip_nodes(&test.sub),
     }
 }
 
-fn emit_result(res: &TestResult, level: usize, quiet: bool) {
-    if !quiet {
-        let msg = match &res.mesg {
+fn create_skip_nodes(tests: &[Test]) -> Vec<TestResultNode> {
+    tests.iter().map(create_skip_node).collect()
+}
+
+fn all_passed(results: &[TestResultNode]) -> bool {
+    results.iter().all(|n| {
+        (n.result.stat == TestState::Pass || n.result.stat == TestState::Skip) && all_passed(&n.sub)
+    })
+}
+
+fn render_default(results: &[TestResultNode], level: usize) {
+    for node in results {
+        let msg = match &node.result.mesg {
             Some(m) => format!(": {}", m),
             None => "".to_string(),
         };
         println!(
             "[ {:^4} ] {:width$}- {}{}",
-            format!("{}", res.stat),
+            format!("{}", node.result.stat),
             "",
-            res.name,
+            node.result.name,
             msg,
             width = level
-        )
-    }
-}
-
-fn test_gen_not_included(test: &Test, level: usize, quiet: bool) {
-    if !quiet {
-        let tr_skip = TestResult {
-            name: test.name.to_string(),
-            stat: TestState::Skip,
-            mesg: None,
-        };
-
-        println!(
-            "[ {:^4} ] {:width$}- {}",
-            format!("{}", tr_skip.stat),
-            "",
-            tr_skip.name,
-            width = level
         );
-        emit_skip(&test.sub, level + INDENT, quiet);
+        render_default(&node.sub, level + INDENT);
     }
 }
 
-fn emit_skip(tests: &[Test], level: usize, quiet: bool) {
-    if !quiet {
-        for t in tests {
-            let tr_skip = TestResult {
-                name: t.name.to_string(),
-                stat: TestState::Skip,
-                mesg: None,
-            };
+fn render_short(results: &[TestResultNode]) {
+    let mut passed = Vec::new();
+    let mut failed = Vec::new();
+    let mut skipped = Vec::new();
 
-            println!(
-                "[ {:^4} ] {:width$}- {}",
-                format!("{}", tr_skip.stat),
-                "",
-                tr_skip.name,
-                width = level
-            );
-            emit_skip(&t.sub, level + INDENT, quiet);
+    flatten_results(results, &mut passed, &mut failed, &mut skipped);
+
+    if !failed.is_empty() {
+        println!("{}", "Failures:".red());
+        for e in &failed {
+            let msg = match &e.mesg {
+                Some(m) => format!(": {}", m),
+                None => String::new(),
+            };
+            println!("[ {:^4} ] - {}{}", "FAIL".red(), e.name, msg);
         }
+    }
+
+    if !skipped.is_empty() {
+        println!("\n{}:", "SKIPPED".yellow());
+        for s in &skipped {
+            println!("[ {:^4} ] - {}", "SKIP".yellow(), s.name);
+        }
+    }
+
+    let total = passed.len() + failed.len() + skipped.len();
+    println!(
+        "\n{} tests: {} passed, {} failed, {} skipped",
+        total,
+        passed.len(),
+        failed.len(),
+        skipped.len(),
+    );
+    if failed.is_empty() {
+        println!("{}", "All tests passed.".green());
+    }
+}
+
+fn flatten_results<'a>(
+    results: &'a [TestResultNode],
+    passed: &mut Vec<&'a TestResult>,
+    failed: &mut Vec<&'a TestResult>,
+    skipped: &mut Vec<&'a TestResult>,
+) {
+    for node in results {
+        match node.result.stat {
+            TestState::Pass => passed.push(&node.result),
+            TestState::Fail => failed.push(&node.result),
+            TestState::Skip => skipped.push(&node.result),
+        }
+        flatten_results(&node.sub, passed, failed, skipped);
     }
 }
 

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -716,32 +716,20 @@ const INDENT: usize = 2;
 
 pub fn cmd(quiet: bool, args: Ok) -> Result<()> {
     let tests = collect_tests();
-    let verbosity = args.verbosity();
-
     let results = run_test(&tests, SEV_MASK | ES_MASK | SNP_MASK);
 
     if !quiet {
-        match verbosity {
+        match args.verbosity() {
             Verbosity::Default => render_default(&results, 0),
             Verbosity::Short => render_short(&results),
             Verbosity::Verbose => render_verbose(&results),
         }
     }
 
-    let passed = all_passed(&results);
-    if passed {
-        Ok(())
-    } else {
-        let msg = match verbosity {
-            Verbosity::Verbose => {
-                "One or more tests in snphost ok reported a failure"
-            }
-            Verbosity::Default | Verbosity::Short => {
-                "One or more tests in snphost ok reported a failure. Run with --verbose for detailed troubleshooting steps"
-            }
-        };
-        Err(anyhow::anyhow!(msg))
+    if !all_passed(&results) {
+        std::process::exit(1);
     }
+    Ok(())
 }
 
 fn run_test(tests: &[Test], mask: usize) -> Vec<TestResultNode> {


### PR DESCRIPTION
## Overview

Add output option to snphost ok command, where user can pass in json to get the snphost ok results in json format. This change is building on top of changes in this PR: https://github.com/virtee/snphost/pull/184. See additional discussion in https://github.com/virtee/snphost/pull/184#discussion_r3046769619.

The `--verbose` flag groups test results by category (CPU Support, BIOS Configured, Platform Initialized, etc.) to help users quickly assess specific areas of system validation, as well as provide hints on how to address the failures. With the change in this MR, the `ok` command can be run with no flags, and either `--short` or `--verbose` but not both.

This PR also includes refactoring `run_test`, so that it focuses solely on executing tests and building a result structure (Vec) and removes all output/rendering logic. This separation of concerns:

* Eliminates the need to pass quiet and level parameters through the test execution
* Replaces the accumulation-based TestResults struct with a tree-structured TestResultNode that mirrors the test hierarchy
* Moves all rendering logic into dedicated functions (render_default, render_short) that traverse the result tree

## Example outputs

<details>
<summary>sudo target/debug/snphost ok</summary>

```bash
[ PASS ] - AMD CPU
[ PASS ]   - Microcode support
[ PASS ]   - Secure Memory Encryption (SME)
[ PASS ]     - SME: Enabled in MSR
[ PASS ]   - Secure Encrypted Virtualization (SEV)
[ PASS ]     - SEV firmware version: 1.55
[ PASS ]     - Encrypted State (SEV-ES)
[ PASS ]       - SEV-ES initialized
[ PASS ]     - SEV initialized: Initialized, no guests running
[ PASS ]     - Secure Nested Paging (SEV-SNP)
[ PASS ]       - VM Permission Levels
[ PASS ]         - Number of VMPLs: 4
[ PASS ]       - SNP: Enabled in MSR
[ PASS ]       - SNP initialized
[ PASS ]         - RMP table addresses: 0xbf8d100000 - 0xc04d6fffff
[ PASS ]         - RMP table initialized
[ FAIL ]         - Alias check
[ PASS ]     - Physical address bit reduction: 6
[ PASS ]     - C-bit location: 51
[ PASS ]     - Number of encrypted guests supported simultaneously: 1006
[ PASS ]     - Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
[ PASS ]     - /dev/sev readable
[ PASS ]     - /dev/sev writable
[ PASS ]   - Page flush MSR: DISABLED
[ PASS ] - KVM supported: API version: 12
[ PASS ]   - SEV enabled in KVM
[ PASS ]   - SEV-ES enabled in KVM
[ PASS ]   - SEV-SNP enabled in KVM
[ PASS ] - Memlock resource limit: Soft: 8388608 | Hard: 8388608
[ PASS ] - Comparing TCB values: TCB versions match

 Platform TCB version: TCB Version:
  Microcode:   72
  SNP:         23
  TEE:         0
  Boot Loader: 8
  FMC:         None
 Reported TCB version: TCB Version:
  Microcode:   72
  SNP:         23
  TEE:         0
  Boot Loader: 8
  FMC:         None
ERROR: One or more tests in snphost ok reported a failure. Run with --verbose for detailed troubleshooting steps
Error: One or more tests in snphost ok reported a failure. Run with --verbose for detailed troubleshooting steps
```

</details>

<details>
<summary>sudo target/debug/snphost ok --verbose</summary>

```bash
=== CPU Support ===
  [ PASS ] AMD CPU
           Checks CPU vendor string via CPUID is "AuthenticAMD"
  [ PASS ] Microcode support
           Verifies processor brand string contains "EPYC" (server-class CPU required)
  [ PASS ] Secure Memory Encryption (SME)
           Checks CPUID 0x8000001F EAX bit 0 for SME hardware support
  [ PASS ] Secure Encrypted Virtualization (SEV)
           Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support
  [ PASS ] Encrypted State (SEV-ES)
           Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support
  [ PASS ] Secure Nested Paging (SEV-SNP)
           Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support
  [ PASS ] VM Permission Levels
           Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support

=== CPU Info ===
  [ PASS ] Number of VMPLs: 4
           Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)
  [ PASS ] Physical address bit reduction: 6
           Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value
  [ PASS ] C-bit location: 51
           Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables
  [ PASS ] Number of encrypted guests supported simultaneously: 1006
           Reads CPUID 0x8000001F ECX for maximum encrypted guest count
  [ PASS ] Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
           Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value
  [ PASS ] Page flush MSR: DISABLED
           Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support

=== BIOS Configured ===
  [ PASS ] SME: Enabled in MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level
  [ PASS ] SEV firmware version: 1.55
           Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)
  [ PASS ] SNP: Enabled in MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level
  [ PASS ] RMP table addresses: 0xbf8d100000 - 0xc04d6fffff
           Reads MSRs 0xC0010132 and 0xC0010133 for RMP base/end addresses

=== Platform Initialized ===
  [ PASS ] SEV-ES initialized
           Queries SEV platform status flags bit 8 for SEV-ES initialization
  [ PASS ] SEV initialized: Initialized, no guests running
           Queries SEV platform status state field (must be Initialized or Working)
  [ PASS ] SNP initialized
           Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)
  [ PASS ] RMP table initialized
           Queries SNP platform status IS_RMP_INIT bit
  [ PASS ] /dev/sev readable
           Attempts to open /dev/sev device for reading
  [ PASS ] /dev/sev writable
           Attempts to open /dev/sev device for writing

=== KVM Config ===
  [ PASS ] KVM supported: API version: 12
           Opens /dev/kvm and queries KVM API version via ioctl
  [ PASS ] SEV enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev for "1" or "Y"
  [ PASS ] SEV-ES enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev_es for "1" or "Y"
  [ PASS ] SEV-SNP enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev_snp for "1" or "Y"

=== Compliance ===
  [ FAIL ] Alias check
           Queries SNP platform status ALIAS_CHECK_COMPLETE bit (CVE-2024-21944 mitigation)
           Recommended: Update firmware/BIOS per AMD-SB-3015. Reboot required
  [ PASS ] Memlock resource limit: Soft: 8388608 | Hard: 8388608
           Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall
  [ PASS ] Comparing TCB values: TCB versions match

              Platform TCB version: TCB Version:
               Microcode:   72
               SNP:         23
               TEE:         0
               Boot Loader: 8
               FMC:         None
              Reported TCB version: TCB Version:
               Microcode:   72
               SNP:         23
               TEE:         0
               Boot Loader: 8
               FMC:         None
           Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS

=== DETECTED ISSUES ===
  1. Alias check [FAIL]
     Hint: Update firmware/BIOS per AMD-SB-3015. Reboot required

ERROR: One or more tests in snphost ok reported a failure
Error: One or more tests in snphost ok reported a failure
```

</details>

<details>
<summary>target/debug/snphost ok</summary>

```bash
[ PASS ] - AMD CPU
[ PASS ]   - Microcode support
[ PASS ]   - Secure Memory Encryption (SME)
[ FAIL ]     - SME: MSR read failed: Error Reading MSR
[ PASS ]   - Secure Encrypted Virtualization (SEV)
[ FAIL ]     - SEV firmware version: Failed to get SEV Platform Status unable to open /dev/sev
[ PASS ]     - Encrypted State (SEV-ES)
[ FAIL ]       - SEV-ES initialized: Failed to get SEV Platform Status unable to open /dev/sev
[ FAIL ]     - SEV initialized: Failed to get SEV Platform Status unable to open /dev/sev
[ PASS ]     - Secure Nested Paging (SEV-SNP)
[ PASS ]       - VM Permission Levels
[ PASS ]         - Number of VMPLs: 4
[ FAIL ]       - SNP: MSR read failed: Error Reading MSR
[ FAIL ]       - SNP initialized: Failed to get SNP Platform status unable to open /dev/sev
[ SKIP ]         - Read RMP tables
[ SKIP ]         - RMP table initialized
[ SKIP ]         - Alias check
[ PASS ]     - Physical address bit reduction: 6
[ PASS ]     - C-bit location: 51
[ PASS ]     - Number of encrypted guests supported simultaneously: 1006
[ PASS ]     - Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
[ FAIL ]     - /dev/sev readable: Not readable: Permission denied (os error 13)
[ FAIL ]     - /dev/sev writable: Not writable: Permission denied (os error 13)
[ PASS ]   - Page flush MSR: DISABLED
[ FAIL ] - KVM supported: Error reading /dev/kvm: (Permission denied (os error 13))
[ SKIP ]   - SEV enabled in KVM
[ SKIP ]   - SEV-ES enabled in KVM
[ SKIP ]   - SEV-SNP enabled in KVM
[ PASS ] - Memlock resource limit: Soft: 8388608 | Hard: 8388608
[ FAIL ] - Comparing TCB values: Failed to get SNP Platform status unable to open /dev/sev
ERROR: One or more tests in snphost ok reported a failure. Run with --verbose for detailed troubleshooting steps
Error: One or more tests in snphost ok reported a failure. Run with --verbose for detailed troubleshooting steps
```

</details>

<details>
<summary>target/debug/snphost ok --verbose</summary>

```bash

=== CPU Support ===
  [ PASS ] AMD CPU
           Checks CPU vendor string via CPUID is "AuthenticAMD"
  [ PASS ] Microcode support
           Verifies processor brand string contains "EPYC" (server-class CPU required)
  [ PASS ] Secure Memory Encryption (SME)
           Checks CPUID 0x8000001F EAX bit 0 for SME hardware support
  [ PASS ] Secure Encrypted Virtualization (SEV)
           Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support
  [ PASS ] Encrypted State (SEV-ES)
           Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support
  [ PASS ] Secure Nested Paging (SEV-SNP)
           Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support
  [ PASS ] VM Permission Levels
           Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support

=== CPU Info ===
  [ PASS ] Number of VMPLs: 4
           Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)
  [ PASS ] Physical address bit reduction: 6
           Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value
  [ PASS ] C-bit location: 51
           Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables
  [ PASS ] Number of encrypted guests supported simultaneously: 1006
           Reads CPUID 0x8000001F ECX for maximum encrypted guest count
  [ PASS ] Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
           Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value
  [ PASS ] Page flush MSR: DISABLED
           Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support

=== BIOS Configured ===
  [ FAIL ] SME: MSR read failed: Error Reading MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level
           Recommended: Load MSR kernel module: sudo modprobe msr
  [ FAIL ] SEV firmware version: Failed to get SEV Platform Status unable to open /dev/sev
           Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] SNP: MSR read failed: Error Reading MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level
           Recommended: Load MSR kernel module: sudo modprobe msr

=== Platform Initialized ===
  [ FAIL ] SEV-ES initialized: Failed to get SEV Platform Status unable to open /dev/sev
           Queries SEV platform status flags bit 8 for SEV-ES initialization
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] SEV initialized: Failed to get SEV Platform Status unable to open /dev/sev
           Queries SEV platform status state field (must be Initialized or Working)
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] SNP initialized: Failed to get SNP Platform status unable to open /dev/sev
           Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] /dev/sev readable: Not readable: Permission denied (os error 13)
           Attempts to open /dev/sev device for reading
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] /dev/sev writable: Not writable: Permission denied (os error 13)
           Attempts to open /dev/sev device for writing
           Recommended: Run with sudo: sudo snphost ok

=== KVM Config ===
  [ FAIL ] KVM supported: Error reading /dev/kvm: (Permission denied (os error 13))
           Opens /dev/kvm and queries KVM API version via ioctl
           Recommended: Run with sudo: sudo snphost ok

=== Compliance ===
  [ PASS ] Memlock resource limit: Soft: 8388608 | Hard: 8388608
           Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall
  [ FAIL ] Comparing TCB values: Failed to get SNP Platform status unable to open /dev/sev
           Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS
           Recommended: Run with sudo: sudo snphost ok

=== DETECTED ISSUES ===
  1. SME [FAIL]
     Hint: Load MSR kernel module: sudo modprobe msr
  2. SEV firmware version [FAIL]
     Hint: Run with sudo: sudo snphost ok
  3. SEV-ES initialized [FAIL]
     Hint: Run with sudo: sudo snphost ok
  4. SEV initialized [FAIL]
     Hint: Run with sudo: sudo snphost ok
  5. SNP [FAIL]
     Hint: Load MSR kernel module: sudo modprobe msr
  6. SNP initialized [FAIL]
     Hint: Run with sudo: sudo snphost ok
  7. /dev/sev readable [FAIL]
     Hint: Run with sudo: sudo snphost ok
  8. /dev/sev writable [FAIL]
     Hint: Run with sudo: sudo snphost ok
  9. KVM supported [FAIL]
     Hint: Run with sudo: sudo snphost ok
  10. Comparing TCB values [FAIL]
     Hint: Run with sudo: sudo snphost ok

ERROR: One or more tests in snphost ok reported a failure
Error: One or more tests in snphost ok reported a failure
```

</details>