### PR TITLE
ok: add json output option, add summary section to verbose output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,9 +346,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "msru"
@@ -598,6 +598,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sev",
+ "strip-ansi-escapes",
 ]
 
 [[package]]
@@ -615,6 +616,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
 
 [[package]]
 name = "strsim"
@@ -688,6 +698,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ msru = "0.2"
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+strip-ansi-escapes = "0.2"

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -11,8 +11,9 @@ use std::{
     str::from_utf8,
 };
 
-use clap::Args;
+use clap::{Args, ValueEnum};
 use colorful::*;
+use serde::{Serialize, Serializer};
 
 use msru::{Accessor, Msr};
 
@@ -21,6 +22,12 @@ enum Verbosity {
     Default,
     Short,
     Verbose,
+}
+
+#[derive(ValueEnum, Clone, Copy, PartialEq, Eq)]
+enum OutputFormat {
+    Default,
+    Json,
 }
 
 #[derive(Args, Clone)]
@@ -32,6 +39,10 @@ pub struct Ok {
     /// Show detailed test descriptions grouped by category with detected issues summary
     #[arg(short, long, conflicts_with = "short")]
     verbose: bool,
+
+    /// Controls how test results are rendered
+    #[arg(short, long, value_enum, default_value_t = OutputFormat::Default)]
+    output: OutputFormat,
 }
 
 impl Ok {
@@ -44,10 +55,15 @@ impl Ok {
             Verbosity::Default
         }
     }
+
+    fn output_format(&self) -> OutputFormat {
+        self.output
+    }
 }
 
 /// Category for grouping tests in verbose output
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 enum TestCategory {
     CpuSupport,
     CpuInfo,
@@ -127,6 +143,20 @@ enum TestState {
     Pass,
     Skip,
     Fail,
+}
+
+impl Serialize for TestState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = match self {
+            TestState::Pass => "pass",
+            TestState::Skip => "skip",
+            TestState::Fail => "fail",
+        };
+        serializer.serialize_str(s)
+    }
 }
 
 enum SevGeneration {
@@ -719,10 +749,11 @@ pub fn cmd(quiet: bool, args: Ok) -> Result<()> {
     let results = run_test(&tests, SEV_MASK | ES_MASK | SNP_MASK);
 
     if !quiet {
-        match args.verbosity() {
-            Verbosity::Default => render_default(&results, 0),
-            Verbosity::Short => render_short(&results),
-            Verbosity::Verbose => render_verbose(&results),
+        match (args.output_format(), args.verbosity()) {
+            (OutputFormat::Json, _) => render_json(&results)?,
+            (OutputFormat::Default, Verbosity::Default) => render_default(&results, 0),
+            (OutputFormat::Default, Verbosity::Short) => render_short(&results),
+            (OutputFormat::Default, Verbosity::Verbose) => render_verbose(&results),
         }
     }
 
@@ -827,21 +858,18 @@ fn render_short(results: &[TestResultNode]) {
         }
     }
 
-    let total = passed.len() + failed.len() + skipped.len();
+    let counts = count_results(results);
     println!(
         "\n{} tests: {} passed, {} failed, {} skipped",
-        total,
-        passed.len(),
-        failed.len(),
-        skipped.len(),
+        counts.total, counts.passed, counts.failed, counts.skipped,
     );
     if failed.is_empty() {
         println!("{}", "All tests passed.".green());
     }
 }
 
-fn render_verbose(results: &[TestResultNode]) {
-    let categories = [
+fn organize_by_category(results: &[TestResultNode]) -> Vec<(TestCategory, Vec<&TestResultNode>)> {
+    let categories_order = [
         TestCategory::CpuSupport,
         TestCategory::CpuInfo,
         TestCategory::BiosConfigured,
@@ -860,16 +888,27 @@ fn render_verbose(results: &[TestResultNode]) {
         .filter(|node| node.result.stat != TestState::Skip)
         .collect();
 
-    for cat in &categories {
+    // Group tests by category
+    let mut categorized = Vec::new();
+    for cat in &categories_order {
         let cat_entries: Vec<_> = all_nodes
             .iter()
             .filter(|node| node.meta.category == *cat)
+            .copied()
             .collect();
 
-        if cat_entries.is_empty() {
-            continue;
+        if !cat_entries.is_empty() {
+            categorized.push((*cat, cat_entries));
         }
+    }
 
+    categorized
+}
+
+fn render_verbose(results: &[TestResultNode]) {
+    let categorized = organize_by_category(results);
+
+    for (cat, cat_entries) in &categorized {
         println!("\n=== {} ===", cat);
         for node in cat_entries {
             let status_colored = match node.result.stat {
@@ -895,9 +934,10 @@ fn render_verbose(results: &[TestResultNode]) {
         }
     }
 
-    // Collect failed tests
-    let failed_nodes: Vec<_> = all_nodes
+    // Collect failed tests from all categories
+    let failed_nodes: Vec<_> = categorized
         .iter()
+        .flat_map(|(_, nodes)| nodes.iter())
         .filter(|node| node.result.stat == TestState::Fail)
         .collect();
 
@@ -914,6 +954,143 @@ fn render_verbose(results: &[TestResultNode]) {
     } else {
         println!("\n{}", "No issues detected.".green());
     }
+
+    let counts = count_results(results);
+    println!(
+        "\n{} tests: {} passed, {} failed, {} skipped",
+        counts.total, counts.passed, counts.failed, counts.skipped,
+    );
+}
+
+fn strip_ansi(s: &str) -> String {
+    String::from_utf8_lossy(&strip_ansi_escapes::strip(s)).to_string()
+}
+
+/// Parse TCB version comparison messages into structured JSON.
+///
+/// **IMPORTANT**: This parser depends on the exact format of TCB messages
+/// generated in `snp_ioctl(SnpStatusTest::Tcb)`. If you modify the message
+/// format in that test, update this parser accordingly.
+///
+/// Expected format:
+/// ```text
+/// TCB versions match \n\n Platform TCB version: <display> \n Reported TCB version: <display>
+/// ```
+/// or
+/// ```text
+/// The TCB versions did NOT match \n\n Platform TCB version: <display> \n Reported TCB version: <display>
+/// ```
+fn parse_tcb_message(msg: &str) -> Option<serde_json::Value> {
+    // Parse TCB version messages into structured JSON
+    if !msg.contains("TCB version") {
+        return None;
+    }
+
+    let parse_tcb_fields = |section: &str| -> serde_json::Value {
+        let mut fields = serde_json::Map::new();
+        for line in section.lines() {
+            let line = line.trim();
+            // Skip the "TCB Version:" header
+            if line == "TCB Version:" || line.is_empty() {
+                continue;
+            }
+            if let Some((key, value)) = line.split_once(':') {
+                let key = key.trim().to_lowercase().replace(' ', "_");
+                let value = value.trim();
+                fields.insert(key, serde_json::json!(value));
+            }
+        }
+        serde_json::Value::Object(fields)
+    };
+
+    let parts: Vec<&str> = msg.split("Platform TCB version:").collect();
+    if parts.len() != 2 {
+        return None;
+    }
+
+    let status = parts[0].trim();
+    let remainder = parts[1];
+
+    let tcb_parts: Vec<&str> = remainder.split("Reported TCB version:").collect();
+    if tcb_parts.len() != 2 {
+        return None;
+    }
+
+    let platform = parse_tcb_fields(tcb_parts[0]);
+    let reported = parse_tcb_fields(tcb_parts[1]);
+
+    Some(serde_json::json!({
+        "match": status == "TCB versions match",
+        "platform_tcb_version": platform,
+        "reported_tcb_version": reported,
+    }))
+}
+
+fn render_json(results: &[TestResultNode]) -> Result<()> {
+    let mut all_nodes = Vec::new();
+    flatten_nodes(results, &mut all_nodes);
+
+    let all_nodes: Vec<_> = all_nodes
+        .into_iter()
+        .filter(|node| node.result.stat != TestState::Skip)
+        .collect();
+
+    let tests: Vec<_> = all_nodes
+        .iter()
+        .map(|node| {
+            let mut test = serde_json::json!({
+                "name": strip_ansi(&node.result.name),
+                "status": node.result.stat,
+                "category": node.meta.category,
+                "description": node.meta.description,
+            });
+
+            if let Some(ref msg) = node.result.mesg {
+                if let Some(structured) = parse_tcb_message(msg) {
+                    test["message"] = structured;
+                } else {
+                    test["message"] = serde_json::json!(strip_ansi(msg));
+                }
+            }
+
+            if node.result.stat == TestState::Fail {
+                let hint = effective_hint(&node.meta, &node.result.mesg);
+                if !hint.is_empty() {
+                    test["fix_hint"] = serde_json::json!(hint);
+                }
+            }
+
+            test
+        })
+        .collect();
+
+    let failures: Vec<_> = all_nodes
+        .iter()
+        .filter(|node| node.result.stat == TestState::Fail)
+        .map(|node| {
+            serde_json::json!({
+                "name": strip_ansi(&node.result.name),
+                "hint": effective_hint(&node.meta, &node.result.mesg),
+            })
+        })
+        .collect();
+
+    let counts = count_results(results);
+
+    let output = serde_json::json!({
+        "tests": tests,
+        "failures": failures,
+        "summary": {
+            "total": counts.total,
+            "passed": counts.passed,
+            "failed": counts.failed,
+            "skipped": counts.skipped
+        }
+    });
+
+    serde_json::to_writer_pretty(std::io::stdout(), &output)?;
+    println!();
+    Ok(())
 }
 
 fn flatten_nodes<'a>(results: &'a [TestResultNode], output: &mut Vec<&'a TestResultNode>) {
@@ -936,6 +1113,33 @@ fn flatten_results<'a>(
             TestState::Skip => skipped.push(&node.result),
         }
         flatten_results(&node.sub, passed, failed, skipped);
+    }
+}
+
+struct TestCounts {
+    passed: usize,
+    failed: usize,
+    skipped: usize,
+    total: usize,
+}
+
+fn count_results(results: &[TestResultNode]) -> TestCounts {
+    let mut passed = Vec::new();
+    let mut failed = Vec::new();
+    let mut skipped = Vec::new();
+
+    flatten_results(results, &mut passed, &mut failed, &mut skipped);
+
+    let passed_count = passed.len();
+    let failed_count = failed.len();
+    let skipped_count = skipped.len();
+    let total = passed_count + failed_count + skipped_count;
+
+    TestCounts {
+        passed: passed_count,
+        failed: failed_count,
+        skipped: skipped_count,
+        total,
     }
 }
 
@@ -1174,18 +1378,20 @@ fn snp_ioctl(test: SnpStatusTest) -> TestResult {
 
     match test {
         SnpStatusTest::Tcb => {
+            // NOTE: This message format is parsed by `parse_tcb_message()` for JSON output.
+            // If you change this format, update that parser as well.
             if status.platform_tcb_version == status.reported_tcb_version {
                 TestResult{
                             name: format!("{}", SnpStatusTest::Tcb),
                             stat: TestState::Pass,
-                            mesg: format!("TCB versions match \n\n Platform TCB version: {} \n Reported TCB version: {}", 
+                            mesg: format!("TCB versions match \n\n Platform TCB version: {} \n Reported TCB version: {}",
                                         status.platform_tcb_version, status.reported_tcb_version).into()
                         }
             } else {
                 TestResult {
                     name: format!("{}", SnpStatusTest::Tcb),
                     stat: TestState::Fail,
-                    mesg: format!("The TCB versions did NOT match \n\n Platform TCB version: {} \n Reported TCB version: {}", 
+                    mesg: format!("The TCB versions did NOT match \n\n Platform TCB version: {} \n Reported TCB version: {}",
                                     status.platform_tcb_version, status.reported_tcb_version).into(),
                 }
             }


### PR DESCRIPTION
## Overview

Add output option to snphost ok command, where user can pass in json to get the snphost ok results in json format. This change is building on top of changes in this PR: https://github.com/virtee/snphost/pull/184. See additional discussion in https://github.com/virtee/snphost/pull/184#discussion_r3046769619.

A benefit of JSON output is that it can enable programmatic parsing, where scripts, monitoring tools, CI/CD pipelines, etc. can easily consume the structured test results instead of parsing human-readable text.

Valid commands:

```
snphost ok
snphost ok -o json
snphost ok --output json
snphost ok --short -o json
snphost ok --verbose -o json
```
`json` output will display the `verbose` option output in json format, so that all fields are available. Commands that end in `json` will default to the `json` output (ie `--short` option will not affect the fields in the json output). 

## Change summary

1. Added `-o json` to snphost ok
2. Added functionality to remove ANSI escape characters from json output fields
3. Added logic to format TCB info in json output

## Example outputs

<details>
<summary>`snphost ok -o json` (same as `snphost ok --short -o json` and `snphost ok --verbose -o json`)</summary>

```
{
  "issues": [
    {
      "hint": "Update firmware/BIOS per AMD-SB-3015. Reboot required",
      "name": "Alias check"
    }
  ],
  "summary": {
    "failed": 1,
    "passed": 29,
    "skipped": 0,
    "total": 30
  },
  "tests": [
    {
      "category": "cpu_support",
      "description": "Checks CPU vendor string via CPUID is \"AuthenticAMD\"",
      "name": "AMD CPU",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Verifies processor brand string contains \"EPYC\" (server-class CPU required)",
      "name": "Microcode support",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 0 for SME hardware support",
      "name": "Secure Memory Encryption (SME)",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level",
      "message": "Enabled in MSR",
      "name": "SME",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support",
      "name": "Secure Encrypted Virtualization (SEV)",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)",
      "message": "1.55",
      "name": "SEV firmware version",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support",
      "name": "Encrypted State (SEV-ES)",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SEV platform status flags bit 8 for SEV-ES initialization",
      "name": "SEV-ES initialized",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SEV platform status state field (must be Initialized or Working)",
      "message": "Initialized, no guests running",
      "name": "SEV initialized",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support",
      "name": "Secure Nested Paging (SEV-SNP)",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support",
      "name": "VM Permission Levels",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)",
      "message": "4",
      "name": "Number of VMPLs",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level",
      "message": "Enabled in MSR",
      "name": "SNP",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)",
      "name": "SNP initialized",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSRs 0xC0010132 and 0xC0010133 for RMP base/end addresses",
      "message": "0xbf8d100000 - 0xc04d6fffff",
      "name": "RMP table addresses",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SNP platform status IS_RMP_INIT bit",
      "name": "RMP table initialized",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Queries SNP platform status ALIAS_CHECK_COMPLETE bit (CVE-2024-21944 mitigation)",
      "fix_hint": "Update firmware/BIOS per AMD-SB-3015. Reboot required",
      "name": "Alias check",
      "status": "fail"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value",
      "message": "6",
      "name": "Physical address bit reduction",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables",
      "message": "51",
      "name": "C-bit location",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F ECX for maximum encrypted guest count",
      "message": "1006",
      "name": "Number of encrypted guests supported simultaneously",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value",
      "message": "100",
      "name": "Minimum ASID value for SEV-enabled, SEV-ES disabled guest",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Attempts to open /dev/sev device for reading",
      "name": "/dev/sev readable",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Attempts to open /dev/sev device for writing",
      "name": "/dev/sev writable",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support",
      "name": "Page flush MSR: DISABLED",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Opens /dev/kvm and queries KVM API version via ioctl",
      "message": "API version: 12",
      "name": "KVM supported",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Reads /sys/module/kvm_amd/parameters/sev for \"1\" or \"Y\"",
      "name": "SEV enabled in KVM",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Reads /sys/module/kvm_amd/parameters/sev_es for \"1\" or \"Y\"",
      "name": "SEV-ES enabled in KVM",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Reads /sys/module/kvm_amd/parameters/sev_snp for \"1\" or \"Y\"",
      "name": "SEV-SNP enabled in KVM",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall",
      "message": "Soft: 8388608 | Hard: 8388608",
      "name": "Memlock resource limit",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS",
      "message": {
        "match": true,
        "platform_tcb_version": {
          "boot_loader": "8",
          "fmc": "None",
          "microcode": "72",
          "snp": "23",
          "tee": "0"
        },
        "reported_tcb_version": {
          "boot_loader": "8",
          "fmc": "None",
          "microcode": "72",
          "snp": "23",
          "tee": "0"
        }
      },
      "name": "Comparing TCB values",
      "status": "pass"
    }
  ]
}

```

</details>

<details>
<summary>snphost ok --verbose</summary>

```

=== CPU Support ===
  [ PASS ] AMD CPU
           Checks CPU vendor string via CPUID is "AuthenticAMD"
  [ PASS ] Microcode support
           Verifies processor brand string contains "EPYC" (server-class CPU required)
  [ PASS ] Secure Memory Encryption (SME)
           Checks CPUID 0x8000001F EAX bit 0 for SME hardware support
  [ PASS ] Secure Encrypted Virtualization (SEV)
           Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support
  [ PASS ] Encrypted State (SEV-ES)
           Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support
  [ PASS ] Secure Nested Paging (SEV-SNP)
           Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support
  [ PASS ] VM Permission Levels
           Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support

=== CPU Info ===
  [ PASS ] Number of VMPLs: 4
           Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)
  [ PASS ] Physical address bit reduction: 6
           Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value
  [ PASS ] C-bit location: 51
           Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables
  [ PASS ] Number of encrypted guests supported simultaneously: 1006
           Reads CPUID 0x8000001F ECX for maximum encrypted guest count
  [ PASS ] Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
           Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value
  [ PASS ] Page flush MSR: DISABLED
           Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support

=== BIOS Configured ===
  [ PASS ] SME: Enabled in MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level
  [ PASS ] SEV firmware version: 1.55
           Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)
  [ PASS ] SNP: Enabled in MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level
  [ PASS ] RMP table addresses: 0xbf8d100000 - 0xc04d6fffff
           Reads MSRs 0xC0010132 and 0xC0010133 for RMP base/end addresses

=== Platform Initialized ===
  [ PASS ] SEV-ES initialized
           Queries SEV platform status flags bit 8 for SEV-ES initialization
  [ PASS ] SEV initialized: Initialized, no guests running
           Queries SEV platform status state field (must be Initialized or Working)
  [ PASS ] SNP initialized
           Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)
  [ PASS ] RMP table initialized
           Queries SNP platform status IS_RMP_INIT bit
  [ PASS ] /dev/sev readable
           Attempts to open /dev/sev device for reading
  [ PASS ] /dev/sev writable
           Attempts to open /dev/sev device for writing

=== KVM Config ===
  [ PASS ] KVM supported: API version: 12
           Opens /dev/kvm and queries KVM API version via ioctl
  [ PASS ] SEV enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev for "1" or "Y"
  [ PASS ] SEV-ES enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev_es for "1" or "Y"
  [ PASS ] SEV-SNP enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev_snp for "1" or "Y"

=== Compliance ===
  [ FAIL ] Alias check
           Queries SNP platform status ALIAS_CHECK_COMPLETE bit (CVE-2024-21944 mitigation)
           Recommended: Update firmware/BIOS per AMD-SB-3015. Reboot required
  [ PASS ] Memlock resource limit: Soft: 8388608 | Hard: 8388608
           Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall
  [ PASS ] Comparing TCB values: TCB versions match

              Platform TCB version: TCB Version:
               Microcode:   72
               SNP:         23
               TEE:         0
               Boot Loader: 8
               FMC:         None
              Reported TCB version: TCB Version:
               Microcode:   72
               SNP:         23
               TEE:         0
               Boot Loader: 8
               FMC:         None
           Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS

=== DETECTED ISSUES ===
  1. Alias check [FAIL]
     Hint: Update firmware/BIOS per AMD-SB-3015. Reboot required


30 tests: 29 passed, 1 failed, 0 skipped

```

</details>
