### PR TITLE
ok: add SecureTSC test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,7 @@ name = "snphost"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "bitflags",
  "clap",
  "colorful",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ is-it-maintained-open-issues = { repository = "virtee/snphost" }
 
 [dependencies]
 anyhow = "1"
+bitflags = "2"
 sev = { version = "8.0.0", features = ['openssl']}
 env_logger = "0.10"
 clap = { version = "4.5", features = [ "derive" ] }

--- a/docs/snphost.1.adoc
+++ b/docs/snphost.1.adoc
@@ -67,9 +67,13 @@ COMMANDS
         related capabilities on the host and emits the results.
 
  options:
-        -s, --short     Show only failures with summary counts
-        -v, --verbose   Show detailed test descriptions grouped by category with detected issues summary
-        -h, --help      Show a help message
+        -s, --short             Show only failures with summary counts
+        -v, --verbose           Show detailed test descriptions grouped by category with detected issues summary
+        -f, --features          Include optional feature tests (skipped by default)
+        -o, --output <OUTPUT>   Controls how test results are rendered. Supported formats:
+                                  default   Human-readable output (default)
+                                  json      Machine-readable JSON output
+        -h, --help              Show a help message
 
 *snphost commit*::
 	usage: snphost commit

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,13 +29,13 @@ Quick reference for diagnosing and fixing `snphost ok` test failures.
 
 ## Test Categories
 
-| Technology | CPU Support | CPU Info | BIOS Configured | Platform Initialized | KVM Config | Compliance |
-|------------|-------------|----------|----------------------|---------------------|------------|------------|
-| **CPU & Platform** | [AMD Processor](#amd-processor)<br><br>[AMD EPYC Processor](#amd-epyc-processor) | [Physical Address Bits](#physical-address-bit-reduction)<br><br>[C-bit Position](#c-bit-position) | [Firmware Version](#firmware-version) | [/dev/sev Readable](#devsev-readable)<br><br>[/dev/sev Writable](#devsev-writable) | [KVM Support](#kvm-support) | [Memlock Limits](#memlock-limits) |
-| **SME** | [SME Support](#sme-support) | | [SME Enabled](#sme-enabled) | | | |
-| **SEV** | [SEV Support](#sev-support) | [Max Guests](#maximum-encrypted-guests)<br><br>[Page Flush MSR](#page-flush-msr-support) | [ASID Limits](#minimum-sev-only-asid) | [SEV Initialized](#sev-initialized) | [SEV Enabled in KVM](#sev-enabled-in-kvm) | |
-| **SEV-ES** | [SEV-ES Support](#sev-es-support) | | | [SEV-ES Initialized](#sev-es-initialized) | [SEV-ES Enabled in KVM](#sev-es-enabled-in-kvm) | |
-| **SEV-SNP** | [SEV-SNP Support](#sev-snp-support) | [VMPL Support](#vmpl-support--count) | [SNP Enabled](#snp-enabled)<br><br>[RMP Addresses](#rmp-addresses) | [SNP Initialized](#snp-initialized)<br><br>[RMP Initialized](#rmp-initialized) | [SEV-SNP Enabled in KVM](#sev-snp-enabled-in-kvm) | [Memory Alias Check](#memory-alias-check)<br><br>[TCB Comparison](#tcb-version-comparison) |
+| Technology | CPU Support | CPU Info | BIOS Configured | Platform Initialized | KVM Config | Compliance | Optional Features |
+|------------|-------------|----------|----------------------|---------------------|------------|------------|-------------------|
+| **CPU & Platform** | [AMD Processor](#amd-processor)<br><br>[AMD EPYC Processor](#amd-epyc-processor) | [Physical Address Bits](#physical-address-bit-reduction)<br><br>[C-bit Position](#c-bit-position) | [Firmware Version](#firmware-version) | [/dev/sev Readable](#devsev-readable)<br><br>[/dev/sev Writable](#devsev-writable) | [KVM Support](#kvm-support) | [Memlock Limits](#memlock-limits) | |
+| **SME** | [SME Support](#sme-support) | | [SME Enabled](#sme-enabled) | | | | |
+| **SEV** | [SEV Support](#sev-support) | [Max Guests](#maximum-encrypted-guests)<br><br>[Page Flush MSR](#page-flush-msr-support) | [ASID Limits](#minimum-sev-only-asid) | [SEV Initialized](#sev-initialized) | [SEV Enabled in KVM](#sev-enabled-in-kvm) | | |
+| **SEV-ES** | [SEV-ES Support](#sev-es-support) | | | [SEV-ES Initialized](#sev-es-initialized) | [SEV-ES Enabled in KVM](#sev-es-enabled-in-kvm) | | |
+| **SEV-SNP** | [SEV-SNP Support](#sev-snp-support) | [VMPL Support](#vmpl-support--count) | [SNP Enabled](#snp-enabled)<br><br>[RMP Addresses](#rmp-addresses) | [SNP Initialized](#snp-initialized)<br><br>[RMP Initialized](#rmp-initialized) | [SEV-SNP Enabled in KVM](#sev-snp-enabled-in-kvm) | [Memory Alias Check](#memory-alias-check)<br><br>[TCB Comparison](#tcb-version-comparison) | [Secure TSC](#secure-tsc) |
 
 **Column Descriptions:**
 - **CPU Support**: CPUID checks - does the processor have this feature?
@@ -537,6 +537,44 @@ sudo snphost config set-reported-tcb
 | FMC | Firmware Management Component (Turin+ only; None on older systems) |
 
 **Expected Mismatch:** If you intentionally set lower Reported TCB for backwards compatibility.
+
+---
+
+## Optional Features
+
+These features enhance SEV guests but are not required for SEV, SEV-ES, or SEV-SNP to function. `snphost ok` does not include these tests by default, but they can be included by running `snphost ok --features`.
+
+### Secure TSC
+
+**Tests:** Platform requirements for enabling the SecureTSC feature during VM launch is met.
+
+Hardware support: CPUID 0x8000001F EAX bit 8 indicates the chip is capable of supporting SecureTSC. This bit is introduced in series 7003 (Milan), but value is not guaranteed to be 1. In practice, 9004 (Genoa) is the first generation where SecureTSC is broadly expected to be available.
+
+Firmware support: There are no firmware requirements on host-side to be able to enable SecureTSC. However, there are two firmware commands needed for interaction with the SecureTSC-enabled guest.
+- MSG_TSC_INFO_REQ is a command that can be executed by the guest kernel to retrieve TSC_INFO. Currently is needed when booting a SecureTSC-enabled VM. This has been introduced prior to SEV firmware version 1.51.
+- SNP_TSC_INFO is a command that can be executed by the host kernel to retrieve TSC_INFO. Currently not called by the kernel, but may be needed for future functionality. This was introduced in SEV firmware version 1.56.
+
+Kernel support: Bit 9 of KVM's `sev_supported_vmsa_features` indicates the kernel supports SecureTSC as a configurable VMSA feature. To launch a SecureTSC-enabled VM, the VMM needs to set bit 9 in `vmsa_features` when calling `KVM_SEV_INIT2` ioctl used to initialize the SEV-SNP context for the VM.
+
+**Platform Requirements:**
+- AMD EPYC 9004 (Genoa) or newer
+- Firmware 1.51 or newer (for SEV-SNP enablement)
+- Linux kernel 6.18+ (host)
+
+**Check:**
+```bash
+# Verify kernel version
+uname -r  # Need 6.18+
+
+# Check KVM VMSA features bitmask
+sudo snphost ok --verbose
+```
+
+**References:** 
+
+[AMD64 Architecture Programmer's Manual, Vol 2, §15.36.18 (Rev 3.44)](https://docs.amd.com/v/u/en-US/24593_3.44_APM_Vol2)
+[AMD EPYC Processor Revision Guide, Erratum 1378: Secure TSC May Not Be Supported](https://www.amd.com/content/dam/amd/en/documents/processor-tech-docs/revision-guides/56683.pdf)
+[SEV Secure Nested Paging Firmware ABI Specification, Revision 1.58, Section 8.17](https://www.amd.com/content/dam/amd/en/documents/developer/56860.pdf)
 
 ---
 

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -919,7 +919,9 @@ fn render_short(results: &[TestResultNode]) {
     }
 }
 
-fn organize_by_category(results: &[TestResultNode]) -> Vec<(TestCategory, Vec<&TestResultNode>)> {
+fn organize_by_category<'a>(
+    flattened_nodes: &[&'a TestResultNode],
+) -> Vec<(TestCategory, Vec<&'a TestResultNode>)> {
     let categories_order = [
         TestCategory::CpuSupport,
         TestCategory::CpuInfo,
@@ -930,22 +932,11 @@ fn organize_by_category(results: &[TestResultNode]) -> Vec<(TestCategory, Vec<&T
         TestCategory::OptionalFeatures,
     ];
 
-    // Flatten the tree structure into a list
-    let mut all_nodes = Vec::new();
-    flatten_nodes(results, &mut all_nodes);
-
-    // Filter out skipped tests
-    let all_nodes: Vec<_> = all_nodes
-        .into_iter()
-        .filter(|node| node.result.stat != TestState::Skip)
-        .collect();
-
-    // Group tests by category
     let mut categorized = Vec::new();
     for cat in &categories_order {
-        let cat_entries: Vec<_> = all_nodes
+        let cat_entries: Vec<_> = flattened_nodes
             .iter()
-            .filter(|node| node.meta.category == *cat)
+            .filter(|node| node.result.stat != TestState::Skip && node.meta.category == *cat)
             .copied()
             .collect();
 
@@ -958,7 +949,10 @@ fn organize_by_category(results: &[TestResultNode]) -> Vec<(TestCategory, Vec<&T
 }
 
 fn render_verbose(results: &[TestResultNode]) {
-    let categorized = organize_by_category(results);
+    let mut all_nodes = Vec::new();
+    flatten_nodes(results, &mut all_nodes);
+
+    let categorized = organize_by_category(&all_nodes);
 
     for (cat, cat_entries) in &categorized {
         println!("\n=== {} ===", cat);
@@ -986,11 +980,13 @@ fn render_verbose(results: &[TestResultNode]) {
         }
     }
 
-    // Collect failed tests from all categories
-    let failed_nodes: Vec<_> = categorized
+    let failed_nodes: Vec<_> = all_nodes
         .iter()
-        .flat_map(|(_, nodes)| nodes.iter())
-        .filter(|node| node.result.stat == TestState::Fail)
+        .filter(|n| n.result.stat == TestState::Fail)
+        .collect();
+    let skipped_nodes: Vec<_> = all_nodes
+        .iter()
+        .filter(|n| n.result.stat == TestState::Skip)
         .collect();
 
     if !failed_nodes.is_empty() {
@@ -1005,6 +1001,13 @@ fn render_verbose(results: &[TestResultNode]) {
         println!();
     } else {
         println!("\n{}", "No issues detected.".green());
+    }
+
+    if !skipped_nodes.is_empty() {
+        println!("\n{}:", "SKIPPED".yellow());
+        for s in &skipped_nodes {
+            println!("[ {:^4} ] - {}", "SKIP".yellow(), s.result.name);
+        }
     }
 
     let counts = count_results(results);
@@ -1084,6 +1087,7 @@ fn render_json(results: &[TestResultNode]) -> Result<()> {
 
     let tests: Vec<_> = all_nodes
         .iter()
+        .filter(|node| node.result.stat != TestState::Skip)
         .map(|node| {
             let mut test = serde_json::json!({
                 "name": strip_ansi(&node.result.name),
@@ -1122,11 +1126,18 @@ fn render_json(results: &[TestResultNode]) -> Result<()> {
         })
         .collect();
 
+    let skipped: Vec<_> = all_nodes
+        .iter()
+        .filter(|node| node.result.stat == TestState::Skip)
+        .map(|node| serde_json::json!(strip_ansi(&node.result.name)))
+        .collect();
+
     let counts = count_results(results);
 
     let output = serde_json::json!({
         "tests": tests,
         "failures": failures,
+        "skipped": skipped,
         "summary": {
             "total": counts.total,
             "passed": counts.passed,

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -40,6 +40,10 @@ pub struct Ok {
     #[arg(short, long, conflicts_with = "short")]
     verbose: bool,
 
+    /// Include optional feature tests (skipped by default)
+    #[arg(short, long)]
+    features: bool,
+
     /// Controls how test results are rendered
     #[arg(short, long, value_enum, default_value_t = OutputFormat::Default)]
     output: OutputFormat,
@@ -71,6 +75,8 @@ enum TestCategory {
     PlatformInitialized,
     KvmConfig,
     Compliance,
+    /// Features that enhance SEV guests but are not required for SEV, SEV-ES, or SEV-SNP.
+    OptionalFeatures,
 }
 
 impl fmt::Display for TestCategory {
@@ -82,6 +88,7 @@ impl fmt::Display for TestCategory {
             TestCategory::PlatformInitialized => write!(f, "Platform Initialized"),
             TestCategory::KvmConfig => write!(f, "KVM Config"),
             TestCategory::Compliance => write!(f, "Compliance"),
+            TestCategory::OptionalFeatures => write!(f, "Optional Features"),
         }
     }
 }
@@ -466,6 +473,46 @@ fn collect_tests() -> Vec<Test> {
                                     }],
                                 },
                                 Test {
+                                    name: "(Optional Feature) Secure TSC",
+                                    gen_mask: SNP_MASK,
+                                    run: Box::new(|| {
+                                        let res = unsafe { x86_64::__cpuid(0x8000_001f) };
+                                        let mut errors = Vec::new();
+
+                                        if (res.eax & (0x1 << 8)) == 0 {
+                                            errors.push(format!(
+                                                "SecureTSC bit 8 not set in CPUID 0x8000001F EAX: {:#010x}",
+                                                res.eax
+                                            ));
+                                        }
+
+                                        match kvm_get_vmsa_features() {
+                                            Ok(f) if (f & (1 << 9)) == 0 => errors.push(format!(
+                                                "SecureTSC bit 9 not set in KVM sev_supported_vmsa_features: {:#018x}",
+                                                f
+                                            )),
+                                            Err(e) => errors.push(e),
+                                            _ => {}
+                                        }
+
+                                        TestResult {
+                                            name: format!("({}) Secure TSC", TestCategory::OptionalFeatures),
+                                            stat: if errors.is_empty() { TestState::Pass } else { TestState::Fail },
+                                            mesg: Some(if errors.is_empty() {
+                                                "Configurable".to_string()
+                                            } else {
+                                                errors.join("; ")
+                                            }),
+                                        }
+                                    }),
+                                    meta: TestMetadata {
+                                        category: TestCategory::OptionalFeatures,
+                                        description: "Checks SecureTSC hardware support, and kernel support",
+                                        fix_hint: "Requires EPYC 9004+ CPU and kernel 6.18+ with sev_snp=1",
+                                    },
+                                    sub: vec![],
+                                },
+                                Test {
                                     name: "SEV-SNP",
                                     gen_mask: SNP_MASK,
                                     run: Box::new(snp_test),
@@ -746,7 +793,7 @@ const INDENT: usize = 2;
 
 pub fn cmd(quiet: bool, args: Ok) -> Result<()> {
     let tests = collect_tests();
-    let results = run_test(&tests, SEV_MASK | ES_MASK | SNP_MASK);
+    let results = run_test(&tests, SEV_MASK | ES_MASK | SNP_MASK, args.features);
 
     if !quiet {
         match (args.output_format(), args.verbosity()) {
@@ -763,10 +810,14 @@ pub fn cmd(quiet: bool, args: Ok) -> Result<()> {
     Ok(())
 }
 
-fn run_test(tests: &[Test], mask: usize) -> Vec<TestResultNode> {
+fn run_test(tests: &[Test], mask: usize, features: bool) -> Vec<TestResultNode> {
     let mut results = Vec::new();
 
     for t in tests {
+        if !features && t.meta.category == TestCategory::OptionalFeatures {
+            continue;
+        }
+
         let node = if (t.gen_mask & mask) != t.gen_mask {
             // Test doesn't match generation mask - skip it and all children
             create_skip_node(t)
@@ -775,7 +826,7 @@ fn run_test(tests: &[Test], mask: usize) -> Vec<TestResultNode> {
             let res = (t.run)();
 
             let sub = match res.stat {
-                TestState::Pass => run_test(&t.sub, mask),
+                TestState::Pass => run_test(&t.sub, mask, features),
                 TestState::Fail => create_skip_nodes(&t.sub),
                 TestState::Skip => unreachable!(),
             };
@@ -876,6 +927,7 @@ fn organize_by_category(results: &[TestResultNode]) -> Vec<(TestCategory, Vec<&T
         TestCategory::PlatformInitialized,
         TestCategory::KvmConfig,
         TestCategory::Compliance,
+        TestCategory::OptionalFeatures,
     ];
 
     // Flatten the tree structure into a list
@@ -1029,11 +1081,6 @@ fn parse_tcb_message(msg: &str) -> Option<serde_json::Value> {
 fn render_json(results: &[TestResultNode]) -> Result<()> {
     let mut all_nodes = Vec::new();
     flatten_nodes(results, &mut all_nodes);
-
-    let all_nodes: Vec<_> = all_nodes
-        .into_iter()
-        .filter(|node| node.result.stat != TestState::Skip)
-        .collect();
 
     let tests: Vec<_> = all_nodes
         .iter()
@@ -1201,6 +1248,44 @@ fn has_kvm_support() -> TestResult {
         stat,
         mesg: Some(mesg),
     }
+}
+
+fn kvm_get_vmsa_features() -> Result<u64, String> {
+    // _IOW(0xAE, 0xe2, struct kvm_device_attr) where struct is 24 bytes
+    // https://docs.kernel.org/virt/kvm/api.html
+    const KVM_GET_DEVICE_ATTR: u64 = 0x4018AEE2;
+    const KVM_X86_GRP_SEV: u32 = 1;
+    const KVM_X86_SEV_VMSA_FEATURES: u64 = 0;
+
+    let kvm = File::open("/dev/kvm").map_err(|e| format!("unable to open /dev/kvm: {}", e))?;
+
+    // Returns the kernel's sev_supported_vmsa_features bitmask.
+    // https://docs.kernel.org/virt/kvm/x86/amd-memory-encryption.html
+    // https://github.com/torvalds/linux/blob/master/arch/x86/include/uapi/asm/kvm.h
+    #[repr(C)]
+    struct KvmDeviceAttr {
+        flags: u32,
+        group: u32,
+        attr: u64,
+        addr: u64,
+    }
+
+    let mut val: u64 = 0;
+    let attr = KvmDeviceAttr {
+        flags: 0,
+        group: KVM_X86_GRP_SEV,
+        attr: KVM_X86_SEV_VMSA_FEATURES,
+        addr: &mut val as *mut u64 as u64,
+    };
+    let r = unsafe { libc::ioctl(kvm.as_raw_fd(), KVM_GET_DEVICE_ATTR, &attr) };
+    if r < 0 {
+        return Err(format!(
+            "KVM_GET_DEVICE_ATTR failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    Ok(val)
 }
 
 fn sev_enabled_in_kvm(gen: SevGeneration) -> TestResult {

--- a/src/ok/kvm.rs
+++ b/src/ok/kvm.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fs::File, os::unix::io::AsRawFd};
+
+use super::{SevGeneration, TestResult, TestState};
+
+pub(super) fn has_kvm_support() -> TestResult {
+    let path = "/dev/kvm";
+
+    let (stat, mesg) = match File::open(path) {
+        Ok(kvm) => {
+            let api_version = unsafe { libc::ioctl(kvm.as_raw_fd(), 0xAE00, 0) };
+            if api_version < 0 {
+                (
+                    TestState::Fail,
+                    "Error - accessing KVM device node failed".to_string(),
+                )
+            } else {
+                (TestState::Pass, format!("API version: {}", api_version))
+            }
+        }
+        Err(e) => (TestState::Fail, format!("Error reading {}: ({})", path, e)),
+    };
+
+    TestResult {
+        name: "KVM supported".to_string(),
+        stat,
+        mesg: Some(mesg),
+    }
+}
+
+pub(super) fn kvm_get_vmsa_features() -> Result<u64, String> {
+    // _IOW(0xAE, 0xe2, struct kvm_device_attr) where struct is 24 bytes
+    // https://docs.kernel.org/virt/kvm/api.html
+    const KVM_GET_DEVICE_ATTR: u64 = 0x4018AEE2;
+    const KVM_X86_GRP_SEV: u32 = 1;
+    const KVM_X86_SEV_VMSA_FEATURES: u64 = 0;
+
+    let kvm = File::open("/dev/kvm").map_err(|e| format!("unable to open /dev/kvm: {}", e))?;
+
+    // Returns the kernel's sev_supported_vmsa_features bitmask.
+    // https://docs.kernel.org/virt/kvm/x86/amd-memory-encryption.html
+    // https://github.com/torvalds/linux/blob/master/arch/x86/include/uapi/asm/kvm.h
+    #[repr(C)]
+    struct KvmDeviceAttr {
+        flags: u32,
+        group: u32,
+        attr: u64,
+        addr: u64,
+    }
+
+    let mut val: u64 = 0;
+    let attr = KvmDeviceAttr {
+        flags: 0,
+        group: KVM_X86_GRP_SEV,
+        attr: KVM_X86_SEV_VMSA_FEATURES,
+        addr: &mut val as *mut u64 as u64,
+    };
+    let r = unsafe { libc::ioctl(kvm.as_raw_fd(), KVM_GET_DEVICE_ATTR, &attr) };
+    if r < 0 {
+        return Err(format!(
+            "KVM_GET_DEVICE_ATTR failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    Ok(val)
+}
+
+pub(super) fn sev_enabled_in_kvm(gen: SevGeneration) -> TestResult {
+    let path_loc = match gen {
+        SevGeneration::Sev => "/sys/module/kvm_amd/parameters/sev",
+        SevGeneration::Es => "/sys/module/kvm_amd/parameters/sev_es",
+        SevGeneration::Snp => "/sys/module/kvm_amd/parameters/sev_snp",
+    };
+    let path = std::path::Path::new(path_loc);
+
+    let (stat, mesg) = if path.exists() {
+        match std::fs::read_to_string(path_loc) {
+            Ok(result) => {
+                if result.trim() == "1" || result.trim() == "Y" {
+                    (TestState::Pass, None)
+                } else {
+                    (
+                        TestState::Fail,
+                        Some(format!(
+                            "Error - contents read from {}: {}",
+                            path_loc,
+                            result.trim()
+                        )),
+                    )
+                }
+            }
+            Err(e) => (
+                TestState::Fail,
+                Some(format!("Error - (unable to read {}): {}", path_loc, e,)),
+            ),
+        }
+    } else {
+        (
+            TestState::Fail,
+            Some(format!("Error - {} does not exist", path_loc)),
+        )
+    };
+
+    TestResult {
+        name: match gen {
+            SevGeneration::Sev => "SEV enabled in KVM",
+            SevGeneration::Es => "SEV-ES enabled in KVM",
+            SevGeneration::Snp => "SEV-SNP enabled in KVM",
+        }
+        .to_string(),
+        stat,
+        mesg,
+    }
+}

--- a/src/ok/kvm.rs
+++ b/src/ok/kvm.rs
@@ -2,7 +2,16 @@
 
 use std::{fs::File, os::unix::io::AsRawFd};
 
+use bitflags::bitflags;
+
 use super::{SevGeneration, TestResult, TestState};
+
+bitflags! {
+    #[derive(Debug)]
+    pub(super) struct VmsaFeatures: u64 {
+        const SECURE_TSC = 1 << 9;
+    }
+}
 
 pub(super) fn has_kvm_support() -> TestResult {
     let path = "/dev/kvm";

--- a/src/ok/mod.rs
+++ b/src/ok/mod.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod kvm;
+
 use super::*;
 
 use std::{
     arch::x86_64,
-    fmt,
-    fs::{self, File},
+    fmt, fs,
     mem::{transmute, MaybeUninit},
-    os::unix::io::AsRawFd,
     str::from_utf8,
 };
 
@@ -1237,114 +1237,15 @@ fn dev_sev_rw(file: &fs::OpenOptions) -> Result<()> {
 }
 
 fn has_kvm_support() -> TestResult {
-    let path = "/dev/kvm";
-
-    let (stat, mesg) = match File::open(path) {
-        Ok(kvm) => {
-            let api_version = unsafe { libc::ioctl(kvm.as_raw_fd(), 0xAE00, 0) };
-            if api_version < 0 {
-                (
-                    TestState::Fail,
-                    "Error - accessing KVM device node failed".to_string(),
-                )
-            } else {
-                (TestState::Pass, format!("API version: {}", api_version))
-            }
-        }
-        Err(e) => (TestState::Fail, format!("Error reading {}: ({})", path, e)),
-    };
-
-    TestResult {
-        name: "KVM supported".to_string(),
-        stat,
-        mesg: Some(mesg),
-    }
+    kvm::has_kvm_support()
 }
 
 fn kvm_get_vmsa_features() -> Result<u64, String> {
-    // _IOW(0xAE, 0xe2, struct kvm_device_attr) where struct is 24 bytes
-    // https://docs.kernel.org/virt/kvm/api.html
-    const KVM_GET_DEVICE_ATTR: u64 = 0x4018AEE2;
-    const KVM_X86_GRP_SEV: u32 = 1;
-    const KVM_X86_SEV_VMSA_FEATURES: u64 = 0;
-
-    let kvm = File::open("/dev/kvm").map_err(|e| format!("unable to open /dev/kvm: {}", e))?;
-
-    // Returns the kernel's sev_supported_vmsa_features bitmask.
-    // https://docs.kernel.org/virt/kvm/x86/amd-memory-encryption.html
-    // https://github.com/torvalds/linux/blob/master/arch/x86/include/uapi/asm/kvm.h
-    #[repr(C)]
-    struct KvmDeviceAttr {
-        flags: u32,
-        group: u32,
-        attr: u64,
-        addr: u64,
-    }
-
-    let mut val: u64 = 0;
-    let attr = KvmDeviceAttr {
-        flags: 0,
-        group: KVM_X86_GRP_SEV,
-        attr: KVM_X86_SEV_VMSA_FEATURES,
-        addr: &mut val as *mut u64 as u64,
-    };
-    let r = unsafe { libc::ioctl(kvm.as_raw_fd(), KVM_GET_DEVICE_ATTR, &attr) };
-    if r < 0 {
-        return Err(format!(
-            "KVM_GET_DEVICE_ATTR failed: {}",
-            std::io::Error::last_os_error()
-        ));
-    }
-
-    Ok(val)
+    kvm::kvm_get_vmsa_features()
 }
 
 fn sev_enabled_in_kvm(gen: SevGeneration) -> TestResult {
-    let path_loc = match gen {
-        SevGeneration::Sev => "/sys/module/kvm_amd/parameters/sev",
-        SevGeneration::Es => "/sys/module/kvm_amd/parameters/sev_es",
-        SevGeneration::Snp => "/sys/module/kvm_amd/parameters/sev_snp",
-    };
-    let path = std::path::Path::new(path_loc);
-
-    let (stat, mesg) = if path.exists() {
-        match std::fs::read_to_string(path_loc) {
-            Ok(result) => {
-                if result.trim() == "1" || result.trim() == "Y" {
-                    (TestState::Pass, None)
-                } else {
-                    (
-                        TestState::Fail,
-                        Some(format!(
-                            "Error - contents read from {}: {}",
-                            path_loc,
-                            result.trim()
-                        )),
-                    )
-                }
-            }
-            Err(e) => (
-                TestState::Fail,
-                Some(format!("Error - (unable to read {}): {}", path_loc, e,)),
-            ),
-        }
-    } else {
-        (
-            TestState::Fail,
-            Some(format!("Error - {} does not exist", path_loc)),
-        )
-    };
-
-    TestResult {
-        name: match gen {
-            SevGeneration::Sev => "SEV enabled in KVM",
-            SevGeneration::Es => "SEV-ES enabled in KVM",
-            SevGeneration::Snp => "SEV-SNP enabled in KVM",
-        }
-        .to_string(),
-        stat,
-        mesg,
-    }
+    kvm::sev_enabled_in_kvm(gen)
 }
 
 fn memlock_rlimit() -> TestResult {

--- a/src/ok/mod.rs
+++ b/src/ok/mod.rs
@@ -487,9 +487,9 @@ fn collect_tests() -> Vec<Test> {
                                         }
 
                                         match kvm_get_vmsa_features() {
-                                            Ok(f) if (f & (1 << 9)) == 0 => errors.push(format!(
-                                                "SecureTSC bit 9 not set in KVM sev_supported_vmsa_features: {:#018x}",
-                                                f
+                                            Ok(features) if features & kvm::VmsaFeatures::SECURE_TSC.bits() == 0 => errors.push(format!(
+                                                "SecureTSC not set in KVM sev_supported_vmsa_features: {:#018x}",
+                                                features
                                             )),
                                             Err(e) => errors.push(e),
                                             _ => {}


### PR DESCRIPTION
## Overview

SecureTSC is an optional sev feature that enhances security of TSC (Time Stamp Counter) in virtualized environments. It is meant to be configured on launch through QEMU by passing the `secure-tsc=on` flag to the `snpguest` object.

Requirements:
1. Host kernel: 6.18+
2. Guest kernel: 6.14+
3. QEMU: Estimated 11.2 (testing done with branch: https://github.com/AMDESE/qemu/tree/snp-securetsc-latest)

## Changes

1. Add test for SecureTSC feature. PASS indicates the host platform can support launch of a SecureTSC enabled VM
4. Add new `OptionalFeatures` test category. Tests that fall under this category indicate SEV capabilities that are configurable for the VM guest, but are not required to launch a confidential VM. SecureTSC is the only Optional Features test at the moment, but more tests are anticipated to be added in the future
5. If `snphost ok` command is run with `--features`, optional feature tests will be run, otherwise they are skipped tests by default
6. Updated troubleshooting.md with new test info

## Open Questions

1. Does the new `--features` flag to snphost ok make sense. We want to indicate to users whether optional SEV features are available on the host system, but at the same time let them know that these features are not required for them to be able to launch a confidential VM. Should we leave off the `--features` flag and let these tests run by default, as long as we indicate that they are for optional features?
2. To determine if the kernel supports SecureTSC configuration, the method `kvm_get_vmsa_features` was added, which retrieves a bitmask of vmsa_features bits of which ALLOWED_SEV_FEATURES set by VMCB must be a subset. From offline discussion, one thing to consider may be moving this functionality to the `sev` library. Would it make sense to keep this here for now, and after adding it to the `sev` library, update the Secure TSC later to use it in the future?


## Example outputs

<details>
<summary>sudo snphost ok</summary>

```
[ PASS ] - AMD CPU
[ PASS ]   - Microcode support
[ PASS ]   - Secure Memory Encryption (SME)
[ FAIL ]     - SME: MSR read failed: Error Reading MSR
[ PASS ]   - Secure Encrypted Virtualization (SEV)
[ FAIL ]     - SEV firmware version: Failed to get SEV Platform Status unable to open /dev/sev
[ PASS ]     - Encrypted State (SEV-ES)
[ FAIL ]       - SEV-ES initialized: Failed to get SEV Platform Status unable to open /dev/sev
[ FAIL ]     - SEV initialized: Failed to get SEV Platform Status unable to open /dev/sev
[ PASS ]     - Secure Nested Paging (SEV-SNP)
[ PASS ]       - VM Permission Levels
[ PASS ]         - Number of VMPLs: 4
[ FAIL ]       - SNP: MSR read failed: Error Reading MSR
[ FAIL ]       - SNP initialized: Failed to get SNP Platform status unable to open /dev/sev
[ SKIP ]         - Read RMP tables
[ SKIP ]         - RMP table initialized
[ SKIP ]         - Alias check
[ PASS ]     - Physical address bit reduction: 6
[ PASS ]     - C-bit location: 51
[ PASS ]     - Number of encrypted guests supported simultaneously: 1006
[ PASS ]     - Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
[ FAIL ]     - /dev/sev readable: Not readable: Permission denied (os error 13)
[ FAIL ]     - /dev/sev writable: Not writable: Permission denied (os error 13)
[ PASS ]   - Page flush MSR: DISABLED
[ FAIL ] - KVM supported: Error reading /dev/kvm: (Permission denied (os error 13))
[ SKIP ]   - SEV enabled in KVM
[ SKIP ]   - SEV-ES enabled in KVM
[ SKIP ]   - SEV-SNP enabled in KVM
[ PASS ] - Memlock resource limit: Soft: 8388608 | Hard: 8388608
[ FAIL ] - Comparing TCB values: Failed to get SNP Platform status unable to open /dev/sev
amd@ruby-969f-os:~/amd-kkin/snphost$ sudo target/debug/snphost ok
[ PASS ] - AMD CPU
[ PASS ]   - Microcode support
[ PASS ]   - Secure Memory Encryption (SME)
[ PASS ]     - SME: Enabled in MSR
[ PASS ]   - Secure Encrypted Virtualization (SEV)
[ PASS ]     - SEV firmware version: 1.55
[ PASS ]     - Encrypted State (SEV-ES)
[ PASS ]       - SEV-ES initialized
[ PASS ]     - SEV initialized: Initialized, no guests running
[ PASS ]     - Secure Nested Paging (SEV-SNP)
[ PASS ]       - VM Permission Levels
[ PASS ]         - Number of VMPLs: 4
[ PASS ]       - SNP: Enabled in MSR
[ PASS ]       - SNP initialized
[ PASS ]         - RMP table addresses: 0xbf8d100000 - 0xc04d6fffff
[ PASS ]         - RMP table initialized
[ FAIL ]         - Alias check
[ PASS ]     - Physical address bit reduction: 6
[ PASS ]     - C-bit location: 51
[ PASS ]     - Number of encrypted guests supported simultaneously: 1006
[ PASS ]     - Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
[ PASS ]     - /dev/sev readable
[ PASS ]     - /dev/sev writable
[ PASS ]   - Page flush MSR: DISABLED
[ PASS ] - KVM supported: API version: 12
[ PASS ]   - SEV enabled in KVM
[ PASS ]   - SEV-ES enabled in KVM
[ PASS ]   - SEV-SNP enabled in KVM
[ PASS ] - Memlock resource limit: Soft: 8388608 | Hard: 8388608
[ PASS ] - Comparing TCB values: TCB versions match

 Platform TCB version: TCB Version:
  Microcode:   72
  SNP:         23
  TEE:         0
  Boot Loader: 8
  FMC:         None
 Reported TCB version: TCB Version:
  Microcode:   72
  SNP:         23
  TEE:         0
  Boot Loader: 8
  FMC:         None
```
</details>

<details>
<summary>sudo snphost ok --features</summary>

```
[ PASS ] - AMD CPU
[ PASS ]   - Microcode support
[ PASS ]   - Secure Memory Encryption (SME)
[ PASS ]     - SME: Enabled in MSR
[ PASS ]   - Secure Encrypted Virtualization (SEV)
[ PASS ]     - SEV firmware version: 1.55
[ PASS ]     - Encrypted State (SEV-ES)
[ PASS ]       - SEV-ES initialized
[ PASS ]     - SEV initialized: Initialized, no guests running
[ PASS ]     - Secure Nested Paging (SEV-SNP)
[ PASS ]       - VM Permission Levels
[ PASS ]         - Number of VMPLs: 4
[ FAIL ]       - (Optional Feature) Secure TSC: SecureTSC bit 9 not set in KVM sev_supported_vmsa_features: 0x0000000000000020
[ PASS ]       - SNP: Enabled in MSR
[ PASS ]       - SNP initialized
[ PASS ]         - RMP table addresses: 0xbf8d100000 - 0xc04d6fffff
[ PASS ]         - RMP table initialized
[ FAIL ]         - Alias check
[ PASS ]     - Physical address bit reduction: 6
[ PASS ]     - C-bit location: 51
[ PASS ]     - Number of encrypted guests supported simultaneously: 1006
[ PASS ]     - Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
[ PASS ]     - /dev/sev readable
[ PASS ]     - /dev/sev writable
[ PASS ]   - Page flush MSR: DISABLED
[ PASS ] - KVM supported: API version: 12
[ PASS ]   - SEV enabled in KVM
[ PASS ]   - SEV-ES enabled in KVM
[ PASS ]   - SEV-SNP enabled in KVM
[ PASS ] - Memlock resource limit: Soft: 8388608 | Hard: 8388608
[ PASS ] - Comparing TCB values: TCB versions match

 Platform TCB version: TCB Version:
  Microcode:   72
  SNP:         23
  TEE:         0
  Boot Loader: 8
  FMC:         None
 Reported TCB version: TCB Version:
  Microcode:   72
  SNP:         23
  TEE:         0
  Boot Loader: 8
  FMC:         None

```
</details>

<details>
<summary>sudo snphost ok --short</summary>

```
Failures:
[ FAIL ] - Alias check

30 tests: 29 passed, 1 failed, 0 skipped
```
</details>

<details>
<summary>sudo snphost ok --short --features</summary>

```
Failures:
[ FAIL ] - (Optional Feature) Secure TSC: SecureTSC bit 9 not set in KVM sev_supported_vmsa_features: 0x0000000000000020
[ FAIL ] - Alias check

31 tests: 29 passed, 2 failed, 0 skipped
```
</details>

<details>
<summary>sudo snphost ok --verbose</summary>

```

=== CPU Support ===
  [ PASS ] AMD CPU
           Checks CPU vendor string via CPUID is "AuthenticAMD"
  [ PASS ] Microcode support
           Verifies processor brand string contains "EPYC" (server-class CPU required)
  [ PASS ] Secure Memory Encryption (SME)
           Checks CPUID 0x8000001F EAX bit 0 for SME hardware support
  [ PASS ] Secure Encrypted Virtualization (SEV)
           Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support
  [ PASS ] Encrypted State (SEV-ES)
           Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support
  [ PASS ] Secure Nested Paging (SEV-SNP)
           Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support
  [ PASS ] VM Permission Levels
           Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support

=== CPU Info ===
  [ PASS ] Number of VMPLs: 4
           Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)
  [ PASS ] Physical address bit reduction: 6
           Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value
  [ PASS ] C-bit location: 51
           Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables
  [ PASS ] Number of encrypted guests supported simultaneously: 1006
           Reads CPUID 0x8000001F ECX for maximum encrypted guest count
  [ PASS ] Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
           Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value
  [ PASS ] Page flush MSR: DISABLED
           Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support

=== BIOS Configured ===
  [ PASS ] SME: Enabled in MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level
  [ PASS ] SEV firmware version: 1.55
           Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)
  [ PASS ] SNP: Enabled in MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level
  [ PASS ] RMP table addresses: 0xbf8d100000 - 0xc04d6fffff
           Reads MSRs 0xC0010132 and 0xC0010133 for RMP base/end addresses

=== Platform Initialized ===
  [ PASS ] SEV-ES initialized
           Queries SEV platform status flags bit 8 for SEV-ES initialization
  [ PASS ] SEV initialized: Initialized, no guests running
           Queries SEV platform status state field (must be Initialized or Working)
  [ PASS ] SNP initialized
           Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)
  [ PASS ] RMP table initialized
           Queries SNP platform status IS_RMP_INIT bit
  [ PASS ] /dev/sev readable
           Attempts to open /dev/sev device for reading
  [ PASS ] /dev/sev writable
           Attempts to open /dev/sev device for writing

=== KVM Config ===
  [ PASS ] KVM supported: API version: 12
           Opens /dev/kvm and queries KVM API version via ioctl
  [ PASS ] SEV enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev for "1" or "Y"
  [ PASS ] SEV-ES enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev_es for "1" or "Y"
  [ PASS ] SEV-SNP enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev_snp for "1" or "Y"

=== Compliance ===
  [ FAIL ] Alias check
           Queries SNP platform status ALIAS_CHECK_COMPLETE bit (CVE-2024-21944 mitigation)
           Recommended: Update firmware/BIOS per AMD-SB-3015. Reboot required
  [ PASS ] Memlock resource limit: Soft: 8388608 | Hard: 8388608
           Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall
  [ PASS ] Comparing TCB values: TCB versions match

              Platform TCB version: TCB Version:
               Microcode:   72
               SNP:         23
               TEE:         0
               Boot Loader: 8
               FMC:         None
              Reported TCB version: TCB Version:
               Microcode:   72
               SNP:         23
               TEE:         0
               Boot Loader: 8
               FMC:         None
           Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS

=== DETECTED ISSUES ===
  1. Alias check [FAIL]
     Hint: Update firmware/BIOS per AMD-SB-3015. Reboot required


30 tests: 29 passed, 1 failed, 1 skipped

```
</details>

<details>
<summary>sudo snphost ok --verbose --features</summary>

```

=== CPU Support ===
  [ PASS ] AMD CPU
           Checks CPU vendor string via CPUID is "AuthenticAMD"
  [ PASS ] Microcode support
           Verifies processor brand string contains "EPYC" (server-class CPU required)
  [ PASS ] Secure Memory Encryption (SME)
           Checks CPUID 0x8000001F EAX bit 0 for SME hardware support
  [ PASS ] Secure Encrypted Virtualization (SEV)
           Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support
  [ PASS ] Encrypted State (SEV-ES)
           Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support
  [ PASS ] Secure Nested Paging (SEV-SNP)
           Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support
  [ PASS ] VM Permission Levels
           Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support

=== CPU Info ===
  [ PASS ] Number of VMPLs: 4
           Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)
  [ PASS ] Physical address bit reduction: 6
           Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value
  [ PASS ] C-bit location: 51
           Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables
  [ PASS ] Number of encrypted guests supported simultaneously: 1006
           Reads CPUID 0x8000001F ECX for maximum encrypted guest count
  [ PASS ] Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
           Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value
  [ PASS ] Page flush MSR: DISABLED
           Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support

=== BIOS Configured ===
  [ PASS ] SME: Enabled in MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level
  [ PASS ] SEV firmware version: 1.55
           Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)
  [ PASS ] SNP: Enabled in MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level
  [ PASS ] RMP table addresses: 0xbf8d100000 - 0xc04d6fffff
           Reads MSRs 0xC0010132 and 0xC0010133 for RMP base/end addresses

=== Platform Initialized ===
  [ PASS ] SEV-ES initialized
           Queries SEV platform status flags bit 8 for SEV-ES initialization
  [ PASS ] SEV initialized: Initialized, no guests running
           Queries SEV platform status state field (must be Initialized or Working)
  [ PASS ] SNP initialized
           Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)
  [ PASS ] RMP table initialized
           Queries SNP platform status IS_RMP_INIT bit
  [ PASS ] /dev/sev readable
           Attempts to open /dev/sev device for reading
  [ PASS ] /dev/sev writable
           Attempts to open /dev/sev device for writing

=== KVM Config ===
  [ PASS ] KVM supported: API version: 12
           Opens /dev/kvm and queries KVM API version via ioctl
  [ PASS ] SEV enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev for "1" or "Y"
  [ PASS ] SEV-ES enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev_es for "1" or "Y"
  [ PASS ] SEV-SNP enabled in KVM
           Reads /sys/module/kvm_amd/parameters/sev_snp for "1" or "Y"

=== Compliance ===
  [ FAIL ] Alias check
           Queries SNP platform status ALIAS_CHECK_COMPLETE bit (CVE-2024-21944 mitigation)
           Recommended: Update firmware/BIOS per AMD-SB-3015. Reboot required
  [ PASS ] Memlock resource limit: Soft: 8388608 | Hard: 8388608
           Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall
  [ PASS ] Comparing TCB values: TCB versions match

              Platform TCB version: TCB Version:
               Microcode:   72
               SNP:         23
               TEE:         0
               Boot Loader: 8
               FMC:         None
              Reported TCB version: TCB Version:
               Microcode:   72
               SNP:         23
               TEE:         0
               Boot Loader: 8
               FMC:         None
           Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS

=== Optional Features ===
  [ FAIL ] (Optional Feature) Secure TSC: SecureTSC bit 9 not set in KVM sev_supported_vmsa_features: 0x0000000000000020
           Checks SecureTSC hardware support and kernel support
           Recommended: Requires EPYC 9004+ CPU and kernel 6.18+ with sev_snp=1

=== DETECTED ISSUES ===
  1. Alias check [FAIL]
     Hint: Update firmware/BIOS per AMD-SB-3015. Reboot required
  4. (Optional Feature) Secure TSC [FAIL]
     Hint: Requires EPYC 9004+ CPU and kernel 6.18+ with sev_snp=1


31 tests: 29 passed, 2 failed, 0 skipped

```
</details>

<details>
<summary>sudo snphost ok -o json</summary>

```
{
  "failures": [
    {
      "hint": "Update firmware/BIOS per AMD-SB-3015. Reboot required",
      "name": "Alias check"
    }
  ],
  "skipped": [],
  "summary": {
    "failed": 1,
    "passed": 29,
    "skipped": 0,
    "total": 30
  },
  "tests": [
    {
      "category": "cpu_support",
      "description": "Checks CPU vendor string via CPUID is \"AuthenticAMD\"",
      "name": "AMD CPU",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Verifies processor brand string contains \"EPYC\" (server-class CPU required)",
      "name": "Microcode support",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 0 for SME hardware support",
      "name": "Secure Memory Encryption (SME)",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level",
      "message": "Enabled in MSR",
      "name": "SME",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support",
      "name": "Secure Encrypted Virtualization (SEV)",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)",
      "message": "1.55",
      "name": "SEV firmware version",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support",
      "name": "Encrypted State (SEV-ES)",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SEV platform status flags bit 8 for SEV-ES initialization",
      "name": "SEV-ES initialized",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SEV platform status state field (must be Initialized or Working)",
      "message": "Initialized, no guests running",
      "name": "SEV initialized",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support",
      "name": "Secure Nested Paging (SEV-SNP)",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support",
      "name": "VM Permission Levels",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)",
      "message": "4",
      "name": "Number of VMPLs",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level",
      "message": "Enabled in MSR",
      "name": "SNP",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)",
      "name": "SNP initialized",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSRs 0xC0010132 and 0xC0010133 for RMP base/end addresses",
      "message": "0xbf8d100000 - 0xc04d6fffff",
      "name": "RMP table addresses",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SNP platform status IS_RMP_INIT bit",
      "name": "RMP table initialized",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Queries SNP platform status ALIAS_CHECK_COMPLETE bit (CVE-2024-21944 mitigation)",
      "fix_hint": "Update firmware/BIOS per AMD-SB-3015. Reboot required",
      "name": "Alias check",
      "status": "fail"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value",
      "message": "6",
      "name": "Physical address bit reduction",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables",
      "message": "51",
      "name": "C-bit location",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F ECX for maximum encrypted guest count",
      "message": "1006",
      "name": "Number of encrypted guests supported simultaneously",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value",
      "message": "100",
      "name": "Minimum ASID value for SEV-enabled, SEV-ES disabled guest",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Attempts to open /dev/sev device for reading",
      "name": "/dev/sev readable",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Attempts to open /dev/sev device for writing",
      "name": "/dev/sev writable",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support",
      "name": "Page flush MSR: DISABLED",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Opens /dev/kvm and queries KVM API version via ioctl",
      "message": "API version: 12",
      "name": "KVM supported",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Reads /sys/module/kvm_amd/parameters/sev for \"1\" or \"Y\"",
      "name": "SEV enabled in KVM",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Reads /sys/module/kvm_amd/parameters/sev_es for \"1\" or \"Y\"",
      "name": "SEV-ES enabled in KVM",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Reads /sys/module/kvm_amd/parameters/sev_snp for \"1\" or \"Y\"",
      "name": "SEV-SNP enabled in KVM",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall",
      "message": "Soft: 8388608 | Hard: 8388608",
      "name": "Memlock resource limit",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS",
      "message": {
        "match": true,
        "platform_tcb_version": {
          "boot_loader": "8",
          "fmc": "None",
          "microcode": "72",
          "snp": "23",
          "tee": "0"
        },
        "reported_tcb_version": {
          "boot_loader": "8",
          "fmc": "None",
          "microcode": "72",
          "snp": "23",
          "tee": "0"
        }
      },
      "name": "Comparing TCB values",
      "status": "pass"
    }
  ]
}
```
</details>

<details>
<summary>sudo snphost ok --features -o  json</summary>

```
{
  "failures": [
    {
      "hint": "Requires EPYC 9004+ CPU and kernel 6.18+ with sev_snp=1",
      "name": "(Optional Feature) Secure TSC"
    },
    {
      "hint": "Update firmware/BIOS per AMD-SB-3015. Reboot required",
      "name": "Alias check"
    }
  ],
  "skipped": [],
  "summary": {
    "failed": 2,
    "passed": 29,
    "skipped": 0,
    "total": 31
  },
  "tests": [
    {
      "category": "cpu_support",
      "description": "Checks CPU vendor string via CPUID is \"AuthenticAMD\"",
      "name": "AMD CPU",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Verifies processor brand string contains \"EPYC\" (server-class CPU required)",
      "name": "Microcode support",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 0 for SME hardware support",
      "name": "Secure Memory Encryption (SME)",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level",
      "message": "Enabled in MSR",
      "name": "SME",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support",
      "name": "Secure Encrypted Virtualization (SEV)",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)",
      "message": "1.55",
      "name": "SEV firmware version",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support",
      "name": "Encrypted State (SEV-ES)",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SEV platform status flags bit 8 for SEV-ES initialization",
      "name": "SEV-ES initialized",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SEV platform status state field (must be Initialized or Working)",
      "message": "Initialized, no guests running",
      "name": "SEV initialized",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support",
      "name": "Secure Nested Paging (SEV-SNP)",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support",
      "name": "VM Permission Levels",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)",
      "message": "4",
      "name": "Number of VMPLs",
      "status": "pass"
    },
    {
      "category": "optional_features",
      "description": "Checks SecureTSC hardware support and kernel support",
      "fix_hint": "Requires EPYC 9004+ CPU and kernel 6.18+ with sev_snp=1",
      "message": "SecureTSC bit 9 not set in KVM sev_supported_vmsa_features: 0x0000000000000020",
      "name": "(Optional Feature) Secure TSC",
      "status": "fail"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level",
      "message": "Enabled in MSR",
      "name": "SNP",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)",
      "name": "SNP initialized",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSRs 0xC0010132 and 0xC0010133 for RMP base/end addresses",
      "message": "0xbf8d100000 - 0xc04d6fffff",
      "name": "RMP table addresses",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SNP platform status IS_RMP_INIT bit",
      "name": "RMP table initialized",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Queries SNP platform status ALIAS_CHECK_COMPLETE bit (CVE-2024-21944 mitigation)",
      "fix_hint": "Update firmware/BIOS per AMD-SB-3015. Reboot required",
      "name": "Alias check",
      "status": "fail"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value",
      "message": "6",
      "name": "Physical address bit reduction",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables",
      "message": "51",
      "name": "C-bit location",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F ECX for maximum encrypted guest count",
      "message": "1006",
      "name": "Number of encrypted guests supported simultaneously",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value",
      "message": "100",
      "name": "Minimum ASID value for SEV-enabled, SEV-ES disabled guest",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Attempts to open /dev/sev device for reading",
      "name": "/dev/sev readable",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Attempts to open /dev/sev device for writing",
      "name": "/dev/sev writable",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support",
      "name": "Page flush MSR: DISABLED",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Opens /dev/kvm and queries KVM API version via ioctl",
      "message": "API version: 12",
      "name": "KVM supported",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Reads /sys/module/kvm_amd/parameters/sev for \"1\" or \"Y\"",
      "name": "SEV enabled in KVM",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Reads /sys/module/kvm_amd/parameters/sev_es for \"1\" or \"Y\"",
      "name": "SEV-ES enabled in KVM",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Reads /sys/module/kvm_amd/parameters/sev_snp for \"1\" or \"Y\"",
      "name": "SEV-SNP enabled in KVM",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall",
      "message": "Soft: 8388608 | Hard: 8388608",
      "name": "Memlock resource limit",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS",
      "message": {
        "match": true,
        "platform_tcb_version": {
          "boot_loader": "8",
          "fmc": "None",
          "microcode": "72",
          "snp": "23",
          "tee": "0"
        },
        "reported_tcb_version": {
          "boot_loader": "8",
          "fmc": "None",
          "microcode": "72",
          "snp": "23",
          "tee": "0"
        }
      },
      "name": "Comparing TCB values",
      "status": "pass"
    }
  ]
}
```
</details>

## Example outputs with skips

<details>
<summary>snphost ok</summary>

```
[ PASS ] - AMD CPU
[ PASS ]   - Microcode support
[ PASS ]   - Secure Memory Encryption (SME)
[ FAIL ]     - SME: MSR read failed: Error Reading MSR
[ PASS ]   - Secure Encrypted Virtualization (SEV)
[ FAIL ]     - SEV firmware version: Failed to get SEV Platform Status unable to open /dev/sev
[ PASS ]     - Encrypted State (SEV-ES)
[ FAIL ]       - SEV-ES initialized: Failed to get SEV Platform Status unable to open /dev/sev
[ FAIL ]     - SEV initialized: Failed to get SEV Platform Status unable to open /dev/sev
[ PASS ]     - Secure Nested Paging (SEV-SNP)
[ PASS ]       - VM Permission Levels
[ PASS ]         - Number of VMPLs: 4
[ FAIL ]       - SNP: MSR read failed: Error Reading MSR
[ FAIL ]       - SNP initialized: Failed to get SNP Platform status unable to open /dev/sev
[ SKIP ]         - Read RMP tables
[ SKIP ]         - RMP table initialized
[ SKIP ]         - Alias check
[ PASS ]     - Physical address bit reduction: 6
[ PASS ]     - C-bit location: 51
[ PASS ]     - Number of encrypted guests supported simultaneously: 1006
[ PASS ]     - Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
[ FAIL ]     - /dev/sev readable: Not readable: Permission denied (os error 13)
[ FAIL ]     - /dev/sev writable: Not writable: Permission denied (os error 13)
[ PASS ]   - Page flush MSR: DISABLED
[ FAIL ] - KVM supported: Error reading /dev/kvm: (Permission denied (os error 13))
[ SKIP ]   - SEV enabled in KVM
[ SKIP ]   - SEV-ES enabled in KVM
[ SKIP ]   - SEV-SNP enabled in KVM
[ PASS ] - Memlock resource limit: Soft: 8388608 | Hard: 8388608
[ FAIL ] - Comparing TCB values: Failed to get SNP Platform status unable to open /dev/sev
```
</details>

<details>
<summary>snphost ok --short</summary>

```
Failures:
[ FAIL ] - SME: MSR read failed: Error Reading MSR
[ FAIL ] - SEV firmware version: Failed to get SEV Platform Status unable to open /dev/sev
[ FAIL ] - SEV-ES initialized: Failed to get SEV Platform Status unable to open /dev/sev
[ FAIL ] - SEV initialized: Failed to get SEV Platform Status unable to open /dev/sev
[ FAIL ] - SNP: MSR read failed: Error Reading MSR
[ FAIL ] - SNP initialized: Failed to get SNP Platform status unable to open /dev/sev
[ FAIL ] - /dev/sev readable: Not readable: Permission denied (os error 13)
[ FAIL ] - /dev/sev writable: Not writable: Permission denied (os error 13)
[ FAIL ] - KVM supported: Error reading /dev/kvm: (Permission denied (os error 13))
[ FAIL ] - Comparing TCB values: Failed to get SNP Platform status unable to open /dev/sev

SKIPPED:
[ SKIP ] - Read RMP tables
[ SKIP ] - RMP table initialized
[ SKIP ] - Alias check
[ SKIP ] - SEV enabled in KVM
[ SKIP ] - SEV-ES enabled in KVM
[ SKIP ] - SEV-SNP enabled in KVM

30 tests: 14 passed, 10 failed, 6 skipped
```
</details>

<details>
<summary>snphost ok --verbose</summary>

```
=== CPU Support ===
  [ PASS ] AMD CPU
           Checks CPU vendor string via CPUID is "AuthenticAMD"
  [ PASS ] Microcode support
           Verifies processor brand string contains "EPYC" (server-class CPU required)
  [ PASS ] Secure Memory Encryption (SME)
           Checks CPUID 0x8000001F EAX bit 0 for SME hardware support
  [ PASS ] Secure Encrypted Virtualization (SEV)
           Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support
  [ PASS ] Encrypted State (SEV-ES)
           Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support
  [ PASS ] Secure Nested Paging (SEV-SNP)
           Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support
  [ PASS ] VM Permission Levels
           Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support

=== CPU Info ===
  [ PASS ] Number of VMPLs: 4
           Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)
  [ PASS ] Physical address bit reduction: 6
           Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value
  [ PASS ] C-bit location: 51
           Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables
  [ PASS ] Number of encrypted guests supported simultaneously: 1006
           Reads CPUID 0x8000001F ECX for maximum encrypted guest count
  [ PASS ] Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 100
           Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value
  [ PASS ] Page flush MSR: DISABLED
           Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support

=== BIOS Configured ===
  [ FAIL ] SME: MSR read failed: Error Reading MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level
           Recommended: Load MSR kernel module: sudo modprobe msr
  [ FAIL ] SEV firmware version: Failed to get SEV Platform Status unable to open /dev/sev
           Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] SNP: MSR read failed: Error Reading MSR
           Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level
           Recommended: Load MSR kernel module: sudo modprobe msr

=== Platform Initialized ===
  [ FAIL ] SEV-ES initialized: Failed to get SEV Platform Status unable to open /dev/sev
           Queries SEV platform status flags bit 8 for SEV-ES initialization
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] SEV initialized: Failed to get SEV Platform Status unable to open /dev/sev
           Queries SEV platform status state field (must be Initialized or Working)
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] SNP initialized: Failed to get SNP Platform status unable to open /dev/sev
           Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] /dev/sev readable: Not readable: Permission denied (os error 13)
           Attempts to open /dev/sev device for reading
           Recommended: Run with sudo: sudo snphost ok
  [ FAIL ] /dev/sev writable: Not writable: Permission denied (os error 13)
           Attempts to open /dev/sev device for writing
           Recommended: Run with sudo: sudo snphost ok

=== KVM Config ===
  [ FAIL ] KVM supported: Error reading /dev/kvm: (Permission denied (os error 13))
           Opens /dev/kvm and queries KVM API version via ioctl
           Recommended: Run with sudo: sudo snphost ok

=== Compliance ===
  [ PASS ] Memlock resource limit: Soft: 8388608 | Hard: 8388608
           Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall
  [ FAIL ] Comparing TCB values: Failed to get SNP Platform status unable to open /dev/sev
           Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS
           Recommended: Run with sudo: sudo snphost ok

=== DETECTED ISSUES ===
  1. SME [FAIL]
     Hint: Load MSR kernel module: sudo modprobe msr
  2. SEV firmware version [FAIL]
     Hint: Run with sudo: sudo snphost ok
  3. SEV-ES initialized [FAIL]
     Hint: Run with sudo: sudo snphost ok
  4. SEV initialized [FAIL]
     Hint: Run with sudo: sudo snphost ok
  7. SNP [FAIL]
     Hint: Load MSR kernel module: sudo modprobe msr
  8. SNP initialized [FAIL]
     Hint: Run with sudo: sudo snphost ok
  9. /dev/sev readable [FAIL]
     Hint: Run with sudo: sudo snphost ok
  10. /dev/sev writable [FAIL]
     Hint: Run with sudo: sudo snphost ok
  11. KVM supported [FAIL]
     Hint: Run with sudo: sudo snphost ok
  12. Comparing TCB values [FAIL]
     Hint: Run with sudo: sudo snphost ok


SKIPPED:
[ SKIP ] - Read RMP tables
[ SKIP ] - RMP table initialized
[ SKIP ] - Alias check
[ SKIP ] - SEV enabled in KVM
[ SKIP ] - SEV-ES enabled in KVM
[ SKIP ] - SEV-SNP enabled in KVM

30 tests: 14 passed, 10 failed, 6 skipped
```
</details>

<details>
<summary>snphost ok -o json</summary>

```
{
  "failures": [
    {
      "hint": "Load MSR kernel module: sudo modprobe msr",
      "name": "SME"
    },
    {
      "hint": "Run with sudo: sudo snphost ok",
      "name": "SEV firmware version"
    },
    {
      "hint": "Run with sudo: sudo snphost ok",
      "name": "SEV-ES initialized"
    },
    {
      "hint": "Run with sudo: sudo snphost ok",
      "name": "SEV initialized"
    },
    {
      "hint": "Load MSR kernel module: sudo modprobe msr",
      "name": "SNP"
    },
    {
      "hint": "Run with sudo: sudo snphost ok",
      "name": "SNP initialized"
    },
    {
      "hint": "Run with sudo: sudo snphost ok",
      "name": "/dev/sev readable"
    },
    {
      "hint": "Run with sudo: sudo snphost ok",
      "name": "/dev/sev writable"
    },
    {
      "hint": "Run with sudo: sudo snphost ok",
      "name": "KVM supported"
    },
    {
      "hint": "Run with sudo: sudo snphost ok",
      "name": "Comparing TCB values"
    }
  ],
  "skipped": [
    "Read RMP tables",
    "RMP table initialized",
    "Alias check",
    "SEV enabled in KVM",
    "SEV-ES enabled in KVM",
    "SEV-SNP enabled in KVM"
  ],
  "summary": {
    "failed": 10,
    "passed": 14,
    "skipped": 6,
    "total": 30
  },
  "tests": [
    {
      "category": "cpu_support",
      "description": "Checks CPU vendor string via CPUID is \"AuthenticAMD\"",
      "name": "AMD CPU",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Verifies processor brand string contains \"EPYC\" (server-class CPU required)",
      "name": "Microcode support",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 0 for SME hardware support",
      "name": "Secure Memory Encryption (SME)",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSR 0xC0010010 (SYSCFG) bit 23 to verify SME enabled at system level",
      "fix_hint": "Load MSR kernel module: sudo modprobe msr",
      "message": "MSR read failed: Error Reading MSR",
      "name": "SME",
      "status": "fail"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 1 for SEV hardware support",
      "name": "Secure Encrypted Virtualization (SEV)",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Queries /dev/sev PLATFORM_STATUS for firmware version (requires >= 1.51 for SNP)",
      "fix_hint": "Run with sudo: sudo snphost ok",
      "message": "Failed to get SEV Platform Status unable to open /dev/sev",
      "name": "SEV firmware version",
      "status": "fail"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 3 for SEV-ES hardware support",
      "name": "Encrypted State (SEV-ES)",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SEV platform status flags bit 8 for SEV-ES initialization",
      "fix_hint": "Run with sudo: sudo snphost ok",
      "message": "Failed to get SEV Platform Status unable to open /dev/sev",
      "name": "SEV-ES initialized",
      "status": "fail"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SEV platform status state field (must be Initialized or Working)",
      "fix_hint": "Run with sudo: sudo snphost ok",
      "message": "Failed to get SEV Platform Status unable to open /dev/sev",
      "name": "SEV initialized",
      "status": "fail"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 4 for SEV-SNP hardware support",
      "name": "Secure Nested Paging (SEV-SNP)",
      "status": "pass"
    },
    {
      "category": "cpu_support",
      "description": "Checks CPUID 0x8000001F EAX bit 5 for VMPL hardware support",
      "name": "VM Permission Levels",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 15:12 for VMPL count (expected: 4)",
      "message": "4",
      "name": "Number of VMPLs",
      "status": "pass"
    },
    {
      "category": "bios_configured",
      "description": "Reads MSR 0xC0010010 (SYSCFG) bit 24 to verify SNP enabled at system level",
      "fix_hint": "Load MSR kernel module: sudo modprobe msr",
      "message": "MSR read failed: Error Reading MSR",
      "name": "SNP",
      "status": "fail"
    },
    {
      "category": "platform_initialized",
      "description": "Queries SNP_PLATFORM_STATUS state field = 1 (INIT state)",
      "fix_hint": "Run with sudo: sudo snphost ok",
      "message": "Failed to get SNP Platform status unable to open /dev/sev",
      "name": "SNP initialized",
      "status": "fail"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 11:6 for PA bit reduction value",
      "message": "6",
      "name": "Physical address bit reduction",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EBX bits 5:0 for encryption bit position in page tables",
      "message": "51",
      "name": "C-bit location",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F ECX for maximum encrypted guest count",
      "message": "1006",
      "name": "Number of encrypted guests supported simultaneously",
      "status": "pass"
    },
    {
      "category": "cpu_info",
      "description": "Reads CPUID 0x8000001F EDX for minimum SEV-only ASID value",
      "message": "100",
      "name": "Minimum ASID value for SEV-enabled, SEV-ES disabled guest",
      "status": "pass"
    },
    {
      "category": "platform_initialized",
      "description": "Attempts to open /dev/sev device for reading",
      "fix_hint": "Run with sudo: sudo snphost ok",
      "message": "Not readable: Permission denied (os error 13)",
      "name": "/dev/sev readable",
      "status": "fail"
    },
    {
      "category": "platform_initialized",
      "description": "Attempts to open /dev/sev device for writing",
      "fix_hint": "Run with sudo: sudo snphost ok",
      "message": "Not writable: Permission denied (os error 13)",
      "name": "/dev/sev writable",
      "status": "fail"
    },
    {
      "category": "cpu_info",
      "description": "Checks CPUID 0x8000001F EAX bit 2 for page flush MSR optimization support",
      "name": "Page flush MSR: DISABLED",
      "status": "pass"
    },
    {
      "category": "kvm_config",
      "description": "Opens /dev/kvm and queries KVM API version via ioctl",
      "fix_hint": "Run with sudo: sudo snphost ok",
      "message": "Error reading /dev/kvm: (Permission denied (os error 13))",
      "name": "KVM supported",
      "status": "fail"
    },
    {
      "category": "compliance",
      "description": "Reads RLIMIT_MEMLOCK soft and hard limits via getrlimit syscall",
      "message": "Soft: 8388608 | Hard: 8388608",
      "name": "Memlock resource limit",
      "status": "pass"
    },
    {
      "category": "compliance",
      "description": "Compares platform_tcb_version with reported_tcb_version from SNP_PLATFORM_STATUS",
      "fix_hint": "Run with sudo: sudo snphost ok",
      "message": "Failed to get SNP Platform status unable to open /dev/sev",
      "name": "Comparing TCB values",
      "status": "fail"
    }
  ]
}
```
</details>
